### PR TITLE
Call JNI ReleaseStringUTFChars after GetStringUTFChars

### DIFF
--- a/rust/src/api.rs
+++ b/rust/src/api.rs
@@ -176,6 +176,7 @@ impl Jvm {
             let _ = cache::get_jni_new_object().or_else(|| cache::set_jni_new_object((**jni_environment).NewObject));
             let _ = cache::get_jni_new_string_utf().or_else(|| cache::set_jni_new_string_utf((**jni_environment).NewStringUTF));
             let _ = cache::get_jni_get_string_utf_chars().or_else(|| cache::set_jni_get_string_utf_chars((**jni_environment).GetStringUTFChars));
+            let _ = cache::get_jni_release_string_utf_chars().or_else(|| cache::set_jni_release_string_utf_chars((**jni_environment).ReleaseStringUTFChars));
             let _ = cache::get_jni_call_object_method().or_else(|| cache::set_jni_call_object_method((**jni_environment).CallObjectMethod));
             let _ = cache::get_jni_call_void_method().or_else(|| cache::set_jni_call_void_method((**jni_environment).CallVoidMethod));
             let _ = cache::get_jni_call_static_object_method().or_else(|| cache::set_jni_call_static_object_method((**jni_environment).CallStaticObjectMethod));

--- a/rust/src/cache.rs
+++ b/rust/src/cache.rs
@@ -46,6 +46,8 @@ pub(crate) type JniNewStringUTF = unsafe extern "system" fn(env: *mut JNIEnv, ut
 #[allow(non_snake_case)]
 pub(crate) type JniGetStringUTFChars = unsafe extern "system" fn(env: *mut JNIEnv, str: jstring, isCopy: *mut jboolean) -> *const c_char;
 #[allow(non_snake_case)]
+pub(crate) type JniReleaseStringUTFChars = unsafe extern "system" fn(env: *mut JNIEnv, str: jstring, utf: *const c_char);
+#[allow(non_snake_case)]
 pub(crate) type JniCallObjectMethod = unsafe extern "C" fn(env: *mut JNIEnv, obj: jobject, methodID: jmethodID, ...) -> jobject;
 #[allow(non_snake_case)]
 pub(crate) type JniCallVoidMethod = unsafe extern "C" fn(env: *mut JNIEnv, obj: jobject, methodID: jmethodID, ...);
@@ -75,6 +77,7 @@ thread_local! {
     pub(crate) static JNI_NEW_OBJECT: RefCell<Option<JniNewObject>> = RefCell::new(None);
     pub(crate) static JNI_NEW_STRING_UTF: RefCell<Option<JniNewStringUTF>> = RefCell::new(None);
     pub(crate) static JNI_GET_STRING_UTF_CHARS: RefCell<Option<JniGetStringUTFChars>> = RefCell::new(None);
+    pub(crate) static JNI_RELEASE_STRING_UTF_CHARS: RefCell<Option<JniReleaseStringUTFChars>> = RefCell::new(None);
     pub(crate) static JNI_CALL_OBJECT_METHOD: RefCell<Option<JniCallObjectMethod>> = RefCell::new(None);
     pub(crate) static JNI_CALL_VOID_METHOD: RefCell<Option<JniCallVoidMethod>> = RefCell::new(None);
     pub(crate) static JNI_CALL_STATIC_OBJECT_METHOD: RefCell<Option<JniCallStaticObjectMethod>> = RefCell::new(None);
@@ -246,6 +249,19 @@ pub(crate) fn set_jni_get_string_utf_chars(j: Option<JniGetStringUTFChars>) -> O
 
 pub(crate) fn get_jni_get_string_utf_chars() -> Option<JniGetStringUTFChars> {
     JNI_GET_STRING_UTF_CHARS.with(|opt| {
+        *opt.borrow()
+    })
+}
+
+pub(crate) fn set_jni_release_string_utf_chars(j: Option<JniReleaseStringUTFChars>) -> Option<JniReleaseStringUTFChars> {
+    JNI_RELEASE_STRING_UTF_CHARS.with(|opt| {
+        *opt.borrow_mut() = j;
+    });
+    get_jni_release_string_utf_chars()
+}
+
+pub(crate) fn get_jni_release_string_utf_chars() -> Option<JniReleaseStringUTFChars> {
+    JNI_RELEASE_STRING_UTF_CHARS.with(|opt| {
         *opt.borrow()
     })
 }

--- a/rust/src/jni_utils.rs
+++ b/rust/src/jni_utils.rs
@@ -302,13 +302,13 @@ pub(crate) fn global_jobject_from_i64(a: &i64, jni_env: *mut JNIEnv) -> errors::
 
 pub fn jstring_to_rust_string(jvm: &Jvm, java_string: jstring) -> errors::Result<String> {
     unsafe {
-        let s = (cache::get_jni_get_string_utf_chars().unwrap())(
+        let s = (opt_to_res(cache::get_jni_get_string_utf_chars())?)(
             jvm.jni_env,
             java_string,
             ptr::null_mut(),
         ) as *mut c_char;
         let rust_string = utils::to_rust_string(s);
-        (cache::get_jni_release_string_utf_chars().unwrap())(
+        (opt_to_res(cache::get_jni_release_string_utf_chars())?)(
             jvm.jni_env,
             java_string,
             s,

--- a/rust/src/jni_utils.rs
+++ b/rust/src/jni_utils.rs
@@ -308,7 +308,11 @@ pub fn jstring_to_rust_string(jvm: &Jvm, java_string: jstring) -> errors::Result
             ptr::null_mut(),
         ) as *mut c_char;
         let rust_string = utils::to_rust_string(s);
-        utils::drop_c_string(s);
+        (cache::get_jni_release_string_utf_chars().unwrap())(
+            jvm.jni_env,
+            java_string,
+            s,
+        );
         Jvm::do_return(jvm.jni_env, rust_string)
     }
 }


### PR DESCRIPTION
When converting from jstring to Rust String, JNI GetStringUTFChars is
called. When the raw FFI C string pointer is converted to a Rust String,
the raw pointer is manually dropped within Rust rather than calling JNI
ReleaseStringUTFChars. This is undefined behaviour, and can cause heap
corruption and crash in some cases.

See the following SO post: https://stackoverflow.com/questions/5859673/should-you-call-releasestringutfchars-if-getstringutfchars-returned-a-copy 