### PR TITLE
recreate jars in exec directory

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -34,6 +34,7 @@ cesu8 = "1.1.0"
 [build-dependencies]
 fs_extra = "1.2"
 dirs = "4.0"
+glob = "0.3"
 java-locator = "0.1"
 sha2 = "0.10"
 


### PR DESCRIPTION
If the jassets jars are missing, automatically recreate them (problem can be reproduced by deleting e.g. `target/debug/jassets` in a project using j4rs and rerun the build, the jars are not recreated).

This solves a (hard to find) caching problem using j4rs in Github Actions. If the `.cargo` and `target` directories are cached but not the `jassets` directory, the jars are not restored and j4rs panics with the cryptic error message `Too many levels of symbolic links` (probably due to browsing `/proc`). This PR fixes this problem.