### PR TITLE
Make codec encode generic

### DIFF
--- a/java/src/main/java/org/astonbitecode/j4rs/api/services/json/Codec.java
+++ b/java/src/main/java/org/astonbitecode/j4rs/api/services/json/Codec.java
@@ -22,7 +22,7 @@ public interface Codec {
     <T> T decode(String json, String className) throws JsonCodecException;
 
 
-    String encode(Object obj) throws JsonCodecException;
+    <T> String encode(T obj) throws JsonCodecException;
 
 
     Object[] decodeArrayContents(String json) throws JsonCodecException;

--- a/java/src/main/java/org/astonbitecode/j4rs/api/value/JsonValueFactory.java
+++ b/java/src/main/java/org/astonbitecode/j4rs/api/value/JsonValueFactory.java
@@ -17,7 +17,7 @@ package org.astonbitecode.j4rs.api.value;
 import org.astonbitecode.j4rs.api.JsonValue;
 
 public class JsonValueFactory {
-    public static JsonValue create(Object obj) {
+    public static <T> JsonValue create(T obj) {
         return obj != null ? new JsonValueImpl(obj) : new NullJsonValueImpl();
     }
 

--- a/java/src/main/java/org/astonbitecode/j4rs/api/value/JsonValueImpl.java
+++ b/java/src/main/java/org/astonbitecode/j4rs/api/value/JsonValueImpl.java
@@ -27,7 +27,7 @@ public class JsonValueImpl implements JsonValue {
     @SuppressWarnings("unused")
     private String className;
 
-    JsonValueImpl(Object obj) {
+    <T> JsonValueImpl(T obj) {
         this.jsonCodec = JsonCodecService.getJsonCodec();
         this.obj = obj;
         try {


### PR DESCRIPTION
## Summary

Mark `Codec.encode()` as generic and all its usages.