### PR TITLE
Fixing bug in filtering methods based on the parameter.

### DIFF
--- a/java/src/main/java/org/astonbitecode/j4rs/utils/Utils.java
+++ b/java/src/main/java/org/astonbitecode/j4rs/utils/Utils.java
@@ -67,4 +67,31 @@ public class Utils {
     public static Class<?> forNameBasedOnArgs(final GeneratedArg[] params) {
         return Arrays.stream(params).map(arg -> arg.getClazz()).reduce((a, b) -> a).orElse(Void.class);
     }
+
+    // Converts primitive types to their wrapper class.  Useful in matching method parameters.
+    public static Class<?> toWrapper(Class<?> clazz) {
+        if (!clazz.isPrimitive())
+            return clazz;
+
+        if (clazz == Integer.TYPE)
+            return Integer.class;
+        if (clazz == Long.TYPE)
+            return Long.class;
+        if (clazz == Boolean.TYPE)
+            return Boolean.class;
+        if (clazz == Byte.TYPE)
+            return Byte.class;
+        if (clazz == Character.TYPE)
+            return Character.class;
+        if (clazz == Float.TYPE)
+            return Float.class;
+        if (clazz == Double.TYPE)
+            return Double.class;
+        if (clazz == Short.TYPE)
+            return Short.class;
+        if (clazz == Void.TYPE)
+            return Void.class;
+
+        return clazz;
+    }
 }

--- a/java/src/test/java/org/astonbitecode/j4rs/api/invocation/JsonInvocationImplTest.java
+++ b/java/src/test/java/org/astonbitecode/j4rs/api/invocation/JsonInvocationImplTest.java
@@ -16,6 +16,7 @@ package org.astonbitecode.j4rs.api.invocation;
 
 import org.astonbitecode.j4rs.api.Instance;
 import org.astonbitecode.j4rs.api.dtos.InvocationArg;
+import org.astonbitecode.j4rs.api.dtos.InvocationArgGenerator;
 import org.astonbitecode.j4rs.api.instantiation.NativeInstantiationImpl;
 import org.astonbitecode.j4rs.errors.InvocationException;
 import org.astonbitecode.j4rs.tests.MyTest;
@@ -154,6 +155,15 @@ public class JsonInvocationImplTest {
         Instance res = ni.invoke("getI");
         Integer i = (Integer) res.getObject();
         assert (i.equals(33));
+    }
+
+    @Test
+    public void invokeMethodInHierarchyParamCheck() {
+        Instance ni = new JsonInvocationImpl(new GrandchildDummy(), GrandchildDummy.class);
+        InvocationArg arg = new InvocationArg(new JsonInvocationImpl(3, Integer.class));
+        Instance res = ni.invoke("checkParam", arg);
+        Integer i = (Integer) res.getObject();
+        assert (i.equals(3));
     }
 
     @Test

--- a/java/src/test/java/org/astonbitecode/j4rs/utils/ChildDummy.java
+++ b/java/src/test/java/org/astonbitecode/j4rs/utils/ChildDummy.java
@@ -24,6 +24,8 @@ public class ChildDummy extends Dummy implements DummyInterface {
         System.out.println("I am doing something...");
     }
 
+    public int checkParam(int i) { return i; }
+
     public DummyMapInterface<String, Object> getMap() {
         return new DummyMapImpl();
     }


### PR DESCRIPTION
Primitive types can be converted to the wrapper class and then used to determine whether the parameter used in `invoke` call may be used with the defined method's parameter.

Found this improvement after using `invoke` from rust code, where the method was not being found due to parameter matching.  The `InvocationArg` was a primitive type where I used a `jobject` to create it.

Left a few extra comments of where I used some debugging print statements, for you to consider including in the code.

Finally, clarified the exception message to help identify that j4rs is not able to match the method, not that the method did not exist at all.

**Thank you** for all of your hard work on this crate.