### PR TITLE
Fix clippy errors

### DIFF
--- a/rust/src/api/invocation_arg.rs
+++ b/rust/src/api/invocation_arg.rs
@@ -721,7 +721,7 @@ mod inv_arg_unit_tests {
             .unwrap()
             .into_primitive()
             .is_ok());
-        assert!(InvocationArg::try_from(1_32)
+        assert!(InvocationArg::try_from(1_i32)
             .unwrap()
             .into_primitive()
             .is_ok());

--- a/rust/src/jni_utils.rs
+++ b/rust/src/jni_utils.rs
@@ -457,27 +457,23 @@ pub(crate) unsafe fn string_from_jobject(
     }
 }
 
-pub fn jstring_to_rust_string(jvm: &Jvm, java_string: jstring) -> errors::Result<String> {
-    unsafe {
-        let s = (opt_to_res(cache::get_jni_get_string_utf_chars())?)(
-            jvm.jni_env,
-            java_string,
-            ptr::null_mut(),
-        ) as *mut c_char;
-        let rust_string = utils::to_rust_string(s);
-        (opt_to_res(cache::get_jni_release_string_utf_chars())?)(jvm.jni_env, java_string, s);
-        Jvm::do_return(jvm.jni_env, rust_string)
-    }
+pub unsafe fn jstring_to_rust_string(jvm: &Jvm, java_string: jstring) -> errors::Result<String> {
+    let s = (opt_to_res(cache::get_jni_get_string_utf_chars())?)(
+        jvm.jni_env,
+        java_string,
+        ptr::null_mut(),
+    ) as *mut c_char;
+    let rust_string = utils::to_rust_string(s);
+    (opt_to_res(cache::get_jni_release_string_utf_chars())?)(jvm.jni_env, java_string, s);
+    Jvm::do_return(jvm.jni_env, rust_string)
 }
 
-pub(crate) fn throw_exception(message: &str, jni_env: *mut JNIEnv) -> errors::Result<i32> {
-    unsafe {
-        let message_jstring = utils::to_c_string_struct(message);
-        let i = (opt_to_res(cache::get_jni_throw_new())?)(
-            jni_env,
-            cache::get_invocation_exception_class()?,
-            message_jstring.as_ptr(),
-        );
-        Ok(i)
-    }
+pub(crate) unsafe fn throw_exception(message: &str, jni_env: *mut JNIEnv) -> errors::Result<i32> {
+    let message_jstring = utils::to_c_string_struct(message);
+    let i = (opt_to_res(cache::get_jni_throw_new())?)(
+        jni_env,
+        cache::get_invocation_exception_class()?,
+        message_jstring.as_ptr(),
+    );
+    Ok(i)
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -123,7 +123,7 @@ pub extern "C" fn Java_org_astonbitecode_j4rs_api_invocation_NativeCallbackToRus
 }
 
 #[no_mangle]
-pub extern "C" fn Java_org_astonbitecode_j4rs_api_invocation_NativeCallbackToRustFutureSupport_failcallbacktochannel(
+pub unsafe extern "C" fn Java_org_astonbitecode_j4rs_api_invocation_NativeCallbackToRustFutureSupport_failcallbacktochannel(
     _jni_env: *mut JNIEnv,
     _class: *const c_void,
     ptr_address: jlong,

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -204,7 +204,7 @@ mod utils_unit_tests {
         assert!(
             primitive_of(&InvocationArg::try_from(1_i16).unwrap()) == Some("short".to_string())
         );
-        assert!(primitive_of(&InvocationArg::try_from(1_32).unwrap()) == Some("int".to_string()));
+        assert!(primitive_of(&InvocationArg::try_from(1_i32).unwrap()) == Some("int".to_string()));
         assert!(primitive_of(&InvocationArg::try_from(1_i64).unwrap()) == Some("long".to_string()));
         assert!(
             primitive_of(&InvocationArg::try_from(0.1_f32).unwrap()) == Some("float".to_string())


### PR DESCRIPTION
This fixes all of the clippy errors on the repo, there are still 258 clippy warnings left, but the errors represent more serious issues so I sought to resolve them before the warnings.

# Issue 1
![image](https://github.com/astonbitecode/j4rs/assets/5120858/32265c57-84b9-4e14-b6bd-7b7bfc02c717)
The `1_32` constants look like they were meant to be `1_i32`, so I changed them.


# Issue 2
All the `unsafe` changes are due to 
![image](https://github.com/astonbitecode/j4rs/assets/5120858/df67e60c-6d9e-40e6-bb7f-bfedbb31d31a)
There is no way for a function to be sound if it dereferences an arbitrary pointer provided via the public interface, so I fixed this issue by marking the functions as unsafe.