### PR TITLE
Document nested class accessor in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ let system_out_field = jvm.field(&system_class, "out");
 // Retrieve an enum constant using the field
 let access_mode_enum = jvm.static_class("java.nio.file.AccessMode")?;
 let access_mode_write = jvm.field(&access_mode_enum, "WRITE")?;
+
+// Retrieve a nested class (note the use of `$` instead of `.`)
+let state = jvm.static_class("java.lang.Thread$State")?;
 ```
 
 `Instances`s of Java `List`s and `Map`s can be created with the `java_list` and `java_map` functions:

--- a/rust/README.md
+++ b/rust/README.md
@@ -69,6 +69,9 @@ let system_out_field = jvm.field(&system_class, "out");
 // Retrieve an enum constant using the field
 let access_mode_enum = jvm.static_class("java.nio.file.AccessMode")?;
 let access_mode_write = jvm.field(&access_mode_enum, "WRITE")?;
+
+// Retrieve a nested class (note the use of `$` instead of `.`)
+let state = jvm.static_class("java.lang.Thread$State")?;
 ```
 
 `Instances`s of Java `List`s and `Map`s can be created with the `java_list` and `java_map` functions:


### PR DESCRIPTION
closes https://github.com/astonbitecode/j4rs/issues/92

I picked a nested class from https://docs.oracle.com/javase/8/docs/api/allclasses-frame.html I went with Thread.State since it seemed the least obscure that I came across.