### PR TITLE
let Jvm live longer

### DIFF
--- a/rust/src/async_api/mod.rs
+++ b/rust/src/async_api/mod.rs
@@ -69,7 +69,8 @@ impl Jvm {
 
         // Create and return the Instance
         let instance = rx.await?;
-        let new_jni_env = Jvm::attach_thread()?.jni_env;
+        let new_jvm = Jvm::attach_thread()?;
+        let new_jni_env = new_jvm.jni_env;
         Self::do_return(new_jni_env, instance)?
     }
 


### PR DESCRIPTION
Thanks for putting up a quick fix for sendable futures!

I tested it with my code base and found an issue with the implementation.

Basically, the result from `Jvm::attach_thread()` is discarded immediately after taking out the pointer, causing the thread to be detached and the error below to occur.

```
FATAL Error in native method: Using JNIEnv in non-java thread
```

Fixing this issue by creating a local variable to let `Jvm` live longer.