### PR TITLE
Prefer std::fs over fs_extra

### DIFF
--- a/rust/src/api/mod.rs
+++ b/rust/src/api/mod.rs
@@ -18,13 +18,12 @@ use std::convert::TryFrom;
 use std::env;
 use std::ops::Drop;
 use std::os::raw::c_void;
-use std::path::{Path, PathBuf, MAIN_SEPARATOR};
+use std::path::{Path, PathBuf};
 use std::ptr;
 use std::sync::mpsc::channel;
 use std::{fs, thread, time};
 use std::borrow::Borrow;
 
-use fs_extra::dir::get_dir_content;
 use jni_sys::{
     self, jint, jobject, jsize, jstring, JNIEnv, JavaVM, JavaVMInitArgs, JavaVMOption,
     JNI_EDETACHED, JNI_EEXIST, JNI_EINVAL, JNI_ENOMEM, JNI_ERR, JNI_EVERSION, JNI_OK, JNI_TRUE,
@@ -1794,22 +1793,24 @@ impl<'a> JvmBuilder<'a> {
         } else {
             // The default classpath contains all the jars in the jassets directory
             let jassets_path = self.get_jassets_path()?;
-            let all_jars = get_dir_content(&jassets_path)?.files;
             // This is the j4rs jar that should be included in the classpath
             let j4rs_jar_to_use = format!("j4rs-{}-jar-with-dependencies.jar", j4rs_version());
             let j4rs_testing_jar_to_use = format!("j4rs-testing-{}.jar", j4rs_version());
             // Filter out possible incorrect jars of j4rs
-            let filtered_jars: Vec<String> = all_jars
-                .into_iter()
-                .filter(|jar_full_path| {
-                    let jarname = jar_full_path
-                        .split(MAIN_SEPARATOR)
-                        .last()
-                        .unwrap_or(jar_full_path);
-                    !jarname.contains("j4rs-") || jarname.ends_with(&j4rs_jar_to_use) || jarname.ends_with(&j4rs_testing_jar_to_use)
-                })
-                .collect();
-            let cp_string = filtered_jars.join(utils::classpath_sep());
+            let mut cp_string = String::new();
+            for entry in std::fs::read_dir(jassets_path)? {
+                let path = entry?.path();
+                if let Some(file_name) = path.file_name().unwrap().to_str() {
+                    if !file_name.contains("j4rs-") || file_name.ends_with(&j4rs_jar_to_use) || file_name.ends_with(&j4rs_testing_jar_to_use) {
+                        if !cp_string.is_empty() {
+                            cp_string.push_str(utils::classpath_sep());
+                        }
+                        if let Some(path) = path.to_str() {
+                            cp_string.push_str(path);
+                        }
+                    }
+                }
+            }
 
             let default_class_path = format!("-Djava.class.path={}", cp_string);
 
@@ -2055,7 +2056,7 @@ mod api_unit_tests {
         let newdir = "./newdir";
         Jvm::copy_j4rs_libs_under(newdir)?;
 
-        let _ = fs_extra::remove_items(&vec![newdir]);
+        let _ = std::fs::remove_dir_all(newdir);
 
         Ok(())
     }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -166,8 +166,6 @@ mod lib_unit_tests {
     use std::thread::JoinHandle;
     use std::{thread, time};
 
-    use fs_extra::remove_items;
-
     use crate::api::{self, JavaClass};
     use crate::provisioning::JavaArtifact;
     use crate::{LocalJarArtifact, MavenArtifactRepo, MavenSettings, Null};
@@ -714,7 +712,7 @@ mod lib_unit_tests {
             jassets_path().unwrap().to_str().unwrap(),
             MAIN_SEPARATOR
         );
-        let _ = remove_items(&vec![to_remove]);
+        let _ = std::fs::remove_dir_all(to_remove);
 
         assert!(jvm.deploy_artifact(&UnknownArtifact {}).is_err());
 
@@ -737,7 +735,7 @@ mod lib_unit_tests {
             jassets_path().unwrap().to_str().unwrap(),
             MAIN_SEPARATOR
         );
-        let _ = remove_items(&vec![to_remove]);
+        let _ = std::fs::remove_dir_all(to_remove);
 
         Ok(())
     }


### PR DESCRIPTION
For simple cases its best to use `std::fs` instead of `fs_extra` since:
*    the standard library is more familiar
*    removes a layer of indirection
*    using `fs_extra` functions causes extra memory allocations that can be avoided by using `std::fs` functions instead.

The new implementation of `default_jassets_path` fixes an infinite loop when `jassets` is not found.

I had originally hoped to be able to remove the `fs_extra` dep but the use of `fs_extra::copy_items` makes a lot of sense to avoid reimplementing the recursive copying logic.
