### PR TITLE
Fix incorrect rerun-if-changed triggering needless rebuilds

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -35,7 +35,6 @@ futures = "0.3"
 
 [build-dependencies]
 fs_extra = "1.3"
-glob = "0.3"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }


### PR DESCRIPTION
The current build.rs has a bug where the build.rs will always be rerun on the second build of the project.
This looks like:
```shell
> rm -r target
> cargo build
  all dependencies and crate is built, build.rs is run for the first time.
> cargo build
  build.rs is rerun, causing crate to go through compilation.
> cargo build
  compilation is skipped entirely since build.rs does not run.
```

This issue is particularly bad for CI systems that cache a single build of the main branch, and then use that cache for testing incoming PRs, since every build is effectively a second build. This means that even PRs that dont touch the crate have to wait for the crate binary to recompile.

The issue is that a `cargo:rerun-if-changed=` is set for an output file of the build.rs.
`cargo:rerun-if-changed=` should only be used for inputs, otherwise we will hit issues like this.

This PR fixes the issue by removing the problem rerun lines.
This will not regress any functionality since we will still rerun when the `rust/jassets/j4rs*.jar` changes.
This additionally let us remove the glob dependency from build.rs since its no longer needed.