### PR TITLE
Run `cargo clippy --fix`

### DIFF
--- a/rust/benches/j4rs_benchmark.rs
+++ b/rust/benches/j4rs_benchmark.rs
@@ -21,7 +21,7 @@ fn do_invocation_w_string_args(jvm: &Jvm, instance: &Instance) -> Instance {
     jvm.invoke(
         instance,
         "echo",
-        &vec![InvocationArg::try_from("a").unwrap()],
+        &[InvocationArg::try_from("a").unwrap()],
     )
     .unwrap()
 }
@@ -30,7 +30,7 @@ fn do_invocation_w_integer_args(jvm: &Jvm, instance: &Instance) -> Instance {
     jvm.invoke(
         instance,
         "echo",
-        &vec![InvocationArg::try_from(33_i32).unwrap()],
+        &[InvocationArg::try_from(33_i32).unwrap()],
     )
     .unwrap()
 }
@@ -40,7 +40,7 @@ fn do_invocation_w_string_args_and_to_rust(jvm: &Jvm, instance: &Instance) {
         .invoke(
             instance,
             "getMyWithArgs",
-            &vec![InvocationArg::try_from("a").unwrap()],
+            &[InvocationArg::try_from("a").unwrap()],
         )
         .unwrap();
     let _: String = jvm.to_rust(s_instance).unwrap();
@@ -51,16 +51,14 @@ fn use_to_rust_deserialized(jvm: &Jvm, instance: &Instance) {
         .invoke(
             instance,
             "addInts",
-            &vec![
-                InvocationArg::try_from(30_i32)
+            &[InvocationArg::try_from(30_i32)
                     .unwrap()
                     .into_primitive()
                     .unwrap(),
                 InvocationArg::try_from(3_i32)
                     .unwrap()
                     .into_primitive()
-                    .unwrap(),
-            ],
+                    .unwrap()],
         )
         .unwrap();
     let _: i32 = jvm.to_rust_deserialized(i_instance).unwrap();
@@ -71,16 +69,14 @@ fn use_to_rust_boxed(jvm: &Jvm, instance: &Instance) {
         .invoke(
             instance,
             "addInts",
-            &vec![
-                InvocationArg::try_from(30_i32)
+            &[InvocationArg::try_from(30_i32)
                     .unwrap()
                     .into_primitive()
                     .unwrap(),
                 InvocationArg::try_from(3_i32)
                     .unwrap()
                     .into_primitive()
-                    .unwrap(),
-            ],
+                    .unwrap()],
         )
         .unwrap();
     let _: Box<i32> = jvm.to_rust_boxed(i_instance).unwrap();

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -84,7 +84,7 @@ fn copy_jars_from_java(jar_source_path: &Path) -> Result<(), J4rsBuildError> {
 
         // Copy only if the files are not the same
         let do_copy = if destination_jar_file.exists() {
-            !are_same_files(&jar_source_path, &destination_jar_file).unwrap_or(true)
+            !are_same_files(jar_source_path, &destination_jar_file).unwrap_or(true)
         } else {
             true
         };

--- a/rust/src/api/instance.rs
+++ b/rust/src/api/instance.rs
@@ -101,7 +101,7 @@ impl Instance {
         Ok(Instance {
             class_name: self.class_name.clone(),
             jinstance: jni_utils::_create_weak_global_ref_from_global_ref(
-                self.jinstance.clone(),
+                self.jinstance,
                 cache::get_thread_local_env()?,
             )?,
             skip_deleting_jobject: false,
@@ -191,7 +191,7 @@ impl<'a> ChainableInstance<'a> {
         instance: &Instance,
         jvm: &'a Jvm,
     ) -> errors::Result<ChainableInstance<'a>> {
-        let cloned = jvm.clone_instance(&instance)?;
+        let cloned = jvm.clone_instance(instance)?;
         Ok(ChainableInstance {
             instance: cloned,
             jvm,
@@ -265,7 +265,7 @@ mod instance_unit_tests {
                 "isNull", 
                 &[InvocationArg::try_from(maybe_null)?])?;
         let is_null: bool = jvm.to_rust(is_null)?;
-        assert_eq!(is_null, true);
+        assert!(is_null);
         Ok(())
     }
 

--- a/rust/src/api/invocation_arg.rs
+++ b/rust/src/api/invocation_arg.rs
@@ -162,18 +162,18 @@ impl InvocationArg {
     fn make_primitive(&mut self) -> errors::Result<()> {
         match utils::primitive_of(self) {
             Some(primitive_repr) => {
-                match self {
-                    &mut InvocationArg::Java {
+                match *self {
+                    InvocationArg::Java {
                         instance: _,
                         ref mut class_name,
                         serialized: _,
                     } => *class_name = primitive_repr,
-                    &mut InvocationArg::Rust {
+                    InvocationArg::Rust {
                         json: _,
                         ref mut class_name,
                         serialized: _,
                     } => *class_name = primitive_repr,
-                    &mut InvocationArg::RustBasic {
+                    InvocationArg::RustBasic {
                         instance: _,
                         ref mut class_name,
                         serialized: _,

--- a/rust/src/api/invocation_arg.rs
+++ b/rust/src/api/invocation_arg.rs
@@ -18,7 +18,6 @@ use std::ptr;
 
 use jni_sys::{jobject, JNIEnv};
 use serde::Serialize;
-use serde_json;
 
 use crate::api::instance::Instance;
 use crate::api::{JavaClass, Jvm, Null};
@@ -153,7 +152,7 @@ impl InvocationArg {
         } else {
             let json = serde_json::to_string(arg)?;
             Ok(InvocationArg::Rust {
-                json: json,
+                json,
                 class_name: class_name.to_string(),
                 serialized: true,
             })
@@ -184,7 +183,7 @@ impl InvocationArg {
             }
             None => Err(errors::J4RsError::JavaError(format!(
                 "Cannot transform to primitive: {}",
-                utils::get_class_name(&self)
+                utils::get_class_name(self)
             ))),
         }
     }
@@ -203,13 +202,13 @@ impl InvocationArg {
     pub fn as_java_ptr_with_global_ref(&self, jni_env: *mut JNIEnv) -> errors::Result<jobject> {
         match self {
             _s @ &InvocationArg::Java { .. } => {
-                jni_utils::invocation_arg_jobject_from_java(&self, jni_env, true)
+                jni_utils::invocation_arg_jobject_from_java(self, jni_env, true)
             }
             _s @ &InvocationArg::Rust { .. } => {
-                jni_utils::invocation_arg_jobject_from_rust_serialized(&self, jni_env, true)
+                jni_utils::invocation_arg_jobject_from_rust_serialized(self, jni_env, true)
             }
             _s @ &InvocationArg::RustBasic { .. } => {
-                jni_utils::invocation_arg_jobject_from_rust_basic(&self, jni_env, true)
+                jni_utils::invocation_arg_jobject_from_rust_basic(self, jni_env, true)
             }
         }
     }
@@ -218,13 +217,13 @@ impl InvocationArg {
     pub fn as_java_ptr_with_local_ref(&self, jni_env: *mut JNIEnv) -> errors::Result<jobject> {
         match self {
             _s @ &InvocationArg::Java { .. } => {
-                jni_utils::invocation_arg_jobject_from_java(&self, jni_env, false)
+                jni_utils::invocation_arg_jobject_from_java(self, jni_env, false)
             }
             _s @ &InvocationArg::Rust { .. } => {
-                jni_utils::invocation_arg_jobject_from_rust_serialized(&self, jni_env, false)
+                jni_utils::invocation_arg_jobject_from_rust_serialized(self, jni_env, false)
             }
             _s @ &InvocationArg::RustBasic { .. } => {
-                jni_utils::invocation_arg_jobject_from_rust_basic(&self, jni_env, false)
+                jni_utils::invocation_arg_jobject_from_rust_basic(self, jni_env, false)
             }
         }
     }
@@ -233,30 +232,26 @@ impl InvocationArg {
     pub fn instance(self) -> errors::Result<Instance> {
         match self {
             InvocationArg::Java { instance: i, .. } => Ok(i),
-            InvocationArg::RustBasic { .. } => Err(errors::J4RsError::RustError(format!(
-                "Invalid operation: Cannot get the instance of an InvocationArg::RustBasic"
-            ))),
-            InvocationArg::Rust { .. } => Err(errors::J4RsError::RustError(format!(
-                "Cannot get the instance from an InvocationArg::Rust"
-            ))),
+            InvocationArg::RustBasic { .. } => Err(errors::J4RsError::RustError("Invalid operation: Cannot get the instance of an InvocationArg::RustBasic".to_string())),
+            InvocationArg::Rust { .. } => Err(errors::J4RsError::RustError("Cannot get the instance from an InvocationArg::Rust".to_string())),
         }
     }
 
     pub fn class_name(&self) -> &str {
         match self {
-            &InvocationArg::Java {
+            InvocationArg::Java {
                 instance: _,
-                ref class_name,
+                class_name,
                 serialized: _,
             } => class_name,
-            &InvocationArg::Rust {
+            InvocationArg::Rust {
                 json: _,
-                ref class_name,
+                class_name,
                 serialized: _,
             } => class_name,
-            &InvocationArg::RustBasic {
+            InvocationArg::RustBasic {
                 instance: _,
-                ref class_name,
+                class_name,
                 serialized: _,
             } => class_name,
         }
@@ -291,8 +286,8 @@ impl From<Instance> for InvocationArg {
         let class_name = instance.class_name.to_owned();
 
         InvocationArg::Java {
-            instance: instance,
-            class_name: class_name,
+            instance,
+            class_name,
             serialized: false,
         }
     }
@@ -331,7 +326,7 @@ impl<'a> TryFrom<&'a [String]> for InvocationArg {
     fn try_from(vec: &'a [String]) -> errors::Result<InvocationArg> {
         let args: errors::Result<Vec<InvocationArg>> = vec
             .iter()
-            .map(|elem| InvocationArg::try_from(elem))
+            .map(InvocationArg::try_from)
             .collect();
         let res =
             Jvm::do_create_java_list(cache::get_thread_local_env()?, cache::J4RS_ARRAY, &args?);
@@ -379,7 +374,7 @@ impl<'a> TryFrom<&'a [bool]> for InvocationArg {
     fn try_from(vec: &'a [bool]) -> errors::Result<InvocationArg> {
         let args: errors::Result<Vec<InvocationArg>> = vec
             .iter()
-            .map(|elem| InvocationArg::try_from(elem))
+            .map(InvocationArg::try_from)
             .collect();
         let res =
             Jvm::do_create_java_list(cache::get_thread_local_env()?, cache::J4RS_ARRAY, &args?);
@@ -399,7 +394,7 @@ impl<'a> TryFrom<&'a [i8]> for InvocationArg {
     fn try_from(vec: &'a [i8]) -> errors::Result<InvocationArg> {
         let args: errors::Result<Vec<InvocationArg>> = vec
             .iter()
-            .map(|elem| InvocationArg::try_from(elem))
+            .map(InvocationArg::try_from)
             .collect();
         let res =
             Jvm::do_create_java_list(cache::get_thread_local_env()?, cache::J4RS_ARRAY, &args?);
@@ -423,7 +418,7 @@ impl<'a> TryFrom<&'a [char]> for InvocationArg {
     fn try_from(vec: &'a [char]) -> errors::Result<InvocationArg> {
         let args: errors::Result<Vec<InvocationArg>> = vec
             .iter()
-            .map(|elem| InvocationArg::try_from(elem))
+            .map(InvocationArg::try_from)
             .collect();
         let res =
             Jvm::do_create_java_list(cache::get_thread_local_env()?, cache::J4RS_ARRAY, &args?);
@@ -447,7 +442,7 @@ impl<'a> TryFrom<&'a [i16]> for InvocationArg {
     fn try_from(vec: &'a [i16]) -> errors::Result<InvocationArg> {
         let args: errors::Result<Vec<InvocationArg>> = vec
             .iter()
-            .map(|elem| InvocationArg::try_from(elem))
+            .map(InvocationArg::try_from)
             .collect();
         let res =
             Jvm::do_create_java_list(cache::get_thread_local_env()?, cache::J4RS_ARRAY, &args?);
@@ -471,7 +466,7 @@ impl<'a> TryFrom<&'a [u16]> for InvocationArg {
     fn try_from(vec: &'a [u16]) -> errors::Result<InvocationArg> {
         let args: errors::Result<Vec<InvocationArg>> = vec
             .iter()
-            .map(|elem| InvocationArg::try_from(elem))
+            .map(InvocationArg::try_from)
             .collect();
         let res =
             Jvm::do_create_java_list(cache::get_thread_local_env()?, cache::J4RS_ARRAY, &args?);
@@ -495,7 +490,7 @@ impl<'a> TryFrom<&'a [i32]> for InvocationArg {
     fn try_from(vec: &'a [i32]) -> errors::Result<InvocationArg> {
         let args: errors::Result<Vec<InvocationArg>> = vec
             .iter()
-            .map(|elem| InvocationArg::try_from(elem))
+            .map(InvocationArg::try_from)
             .collect();
         let res =
             Jvm::do_create_java_list(cache::get_thread_local_env()?, cache::J4RS_ARRAY, &args?);
@@ -515,7 +510,7 @@ impl<'a> TryFrom<&'a [i64]> for InvocationArg {
     fn try_from(vec: &'a [i64]) -> errors::Result<InvocationArg> {
         let args: errors::Result<Vec<InvocationArg>> = vec
             .iter()
-            .map(|elem| InvocationArg::try_from(elem))
+            .map(InvocationArg::try_from)
             .collect();
         let res =
             Jvm::do_create_java_list(cache::get_thread_local_env()?, cache::J4RS_ARRAY, &args?);
@@ -539,7 +534,7 @@ impl<'a> TryFrom<&'a [f32]> for InvocationArg {
     fn try_from(vec: &'a [f32]) -> errors::Result<InvocationArg> {
         let args: errors::Result<Vec<InvocationArg>> = vec
             .iter()
-            .map(|elem| InvocationArg::try_from(elem))
+            .map(InvocationArg::try_from)
             .collect();
         let res =
             Jvm::do_create_java_list(cache::get_thread_local_env()?, cache::J4RS_ARRAY, &args?);
@@ -563,7 +558,7 @@ impl<'a> TryFrom<&'a [f64]> for InvocationArg {
     fn try_from(vec: &'a [f64]) -> errors::Result<InvocationArg> {
         let args: errors::Result<Vec<InvocationArg>> = vec
             .iter()
-            .map(|elem| InvocationArg::try_from(elem))
+            .map(InvocationArg::try_from)
             .collect();
         let res =
             Jvm::do_create_java_list(cache::get_thread_local_env()?, cache::J4RS_ARRAY, &args?);

--- a/rust/src/api/mod.rs
+++ b/rust/src/api/mod.rs
@@ -1801,7 +1801,8 @@ impl<'a> JvmBuilder<'a> {
     ///
     /// If not, you will get exceptions like the following:
     ///
-    /// > java.lang.NoSuchMethodError: java.net.URLClassLoader.`<init>`(Ljava/lang/String;[Ljava/net/URL;Ljava/lang/ClassLoader;)V
+    /// ```text
+    /// java.lang.NoSuchMethodError: java.net.URLClassLoader.`<init>`(Ljava/lang/String;[Ljava/net/URL;Ljava/lang/ClassLoader;)V
     ///         at org.astonbitecode.j4rs.api.deploy.J4rsClassLoader.`<init>`(J4rsClassLoader.java:22)
     ///         at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
     ///         at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
@@ -1812,6 +1813,7 @@ impl<'a> JvmBuilder<'a> {
     ///         at java.security.AccessController.doPrivileged(Native Method)
     ///         at java.lang.ClassLoader.initSystemClassLoader(ClassLoader.java:1449)
     ///         at java.lang.ClassLoader.getSystemClassLoader(ClassLoader.java:1429)
+    /// ```
     pub fn with_default_classloader(&'a mut self) -> &'a mut JvmBuilder {
         self.default_classloader = true;
         self

--- a/rust/src/api/mod.rs
+++ b/rust/src/api/mod.rs
@@ -31,7 +31,6 @@ use jni_sys::{
 };
 use libc::c_char;
 use serde::de::DeserializeOwned;
-use serde_json;
 
 use instance::{ChainableInstance, Instance, InstanceReceiver};
 
@@ -51,39 +50,39 @@ pub(crate) mod invocation_arg;
 // Initialize the environment
 include!(concat!(env!("OUT_DIR"), "/j4rs_init.rs"));
 
-const CLASS_STRING: &'static str = "java.lang.String";
-const CLASS_BOOLEAN: &'static str = "java.lang.Boolean";
-const CLASS_BYTE: &'static str = "java.lang.Byte";
-const CLASS_CHARACTER: &'static str = "java.lang.Character";
-const CLASS_SHORT: &'static str = "java.lang.Short";
-const CLASS_INTEGER: &'static str = "java.lang.Integer";
-const CLASS_LONG: &'static str = "java.lang.Long";
-const CLASS_FLOAT: &'static str = "java.lang.Float";
-const CLASS_DOUBLE: &'static str = "java.lang.Double";
-const CLASS_LIST: &'static str = "java.util.List";
-pub(crate) const PRIMITIVE_BOOLEAN: &'static str = "boolean";
-pub(crate) const PRIMITIVE_BYTE: &'static str = "byte";
-pub(crate) const PRIMITIVE_SHORT: &'static str = "short";
-pub(crate) const PRIMITIVE_INT: &'static str = "int";
-pub(crate) const PRIMITIVE_LONG: &'static str = "long";
-pub(crate) const PRIMITIVE_FLOAT: &'static str = "float";
-pub(crate) const PRIMITIVE_DOUBLE: &'static str = "double";
-pub(crate) const PRIMITIVE_CHAR: &'static str = "char";
+const CLASS_STRING: &str = "java.lang.String";
+const CLASS_BOOLEAN: &str = "java.lang.Boolean";
+const CLASS_BYTE: &str = "java.lang.Byte";
+const CLASS_CHARACTER: &str = "java.lang.Character";
+const CLASS_SHORT: &str = "java.lang.Short";
+const CLASS_INTEGER: &str = "java.lang.Integer";
+const CLASS_LONG: &str = "java.lang.Long";
+const CLASS_FLOAT: &str = "java.lang.Float";
+const CLASS_DOUBLE: &str = "java.lang.Double";
+const CLASS_LIST: &str = "java.util.List";
+pub(crate) const PRIMITIVE_BOOLEAN: &str = "boolean";
+pub(crate) const PRIMITIVE_BYTE: &str = "byte";
+pub(crate) const PRIMITIVE_SHORT: &str = "short";
+pub(crate) const PRIMITIVE_INT: &str = "int";
+pub(crate) const PRIMITIVE_LONG: &str = "long";
+pub(crate) const PRIMITIVE_FLOAT: &str = "float";
+pub(crate) const PRIMITIVE_DOUBLE: &str = "double";
+pub(crate) const PRIMITIVE_CHAR: &str = "char";
 
-pub(crate) const PRIMITIVE_BOOLEAN_ARRAY: &'static str = "[Z";
-pub(crate) const PRIMITIVE_BYTE_ARRAY: &'static str = "[B";
-pub(crate) const PRIMITIVE_SHORT_ARRAY: &'static str = "[S";
-pub(crate) const PRIMITIVE_INT_ARRAY: &'static str = "[I";
-pub(crate) const PRIMITIVE_LONG_ARRAY: &'static str = "[J";
-pub(crate) const PRIMITIVE_FLOAT_ARRAY: &'static str = "[F";
-pub(crate) const PRIMITIVE_DOUBLE_ARRAY: &'static str = "[D";
-pub(crate) const PRIMITIVE_CHAR_ARRAY: &'static str = "[C";
+pub(crate) const PRIMITIVE_BOOLEAN_ARRAY: &str = "[Z";
+pub(crate) const PRIMITIVE_BYTE_ARRAY: &str = "[B";
+pub(crate) const PRIMITIVE_SHORT_ARRAY: &str = "[S";
+pub(crate) const PRIMITIVE_INT_ARRAY: &str = "[I";
+pub(crate) const PRIMITIVE_LONG_ARRAY: &str = "[J";
+pub(crate) const PRIMITIVE_FLOAT_ARRAY: &str = "[F";
+pub(crate) const PRIMITIVE_DOUBLE_ARRAY: &str = "[D";
+pub(crate) const PRIMITIVE_CHAR_ARRAY: &str = "[C";
 
-pub(crate) const CLASS_NATIVE_CALLBACK_TO_RUST_CHANNEL_SUPPORT: &'static str =
+pub(crate) const CLASS_NATIVE_CALLBACK_TO_RUST_CHANNEL_SUPPORT: &str =
     "org.astonbitecode.j4rs.api.invocation.NativeCallbackToRustChannelSupport";
-pub(crate) const CLASS_J4RS_EVENT_HANDLER: &'static str =
+pub(crate) const CLASS_J4RS_EVENT_HANDLER: &str =
     "org.astonbitecode.j4rs.api.jfx.handlers.J4rsEventHandler";
-pub(crate) const CLASS_J4RS_FXML_LOADER: &'static str =
+pub(crate) const CLASS_J4RS_FXML_LOADER: &str =
     "org.astonbitecode.j4rs.api.jfx.J4rsFxmlLoader";
 pub const _JNI_VERSION_10: jint = 0x000a0000;
 
@@ -181,7 +180,7 @@ impl Jvm {
 
                 cstrings_to_drop
                     .into_iter()
-                    .for_each(|cstr| utils::drop_c_string(cstr));
+                    .for_each(utils::drop_c_string);
 
                 int_result
             };
@@ -214,7 +213,7 @@ impl Jvm {
                 jvm.invoke_static(
                     CLASS_NATIVE_CALLBACK_TO_RUST_CHANNEL_SUPPORT,
                     "initialize",
-                    &vec![InvocationArg::try_from(libname)?],
+                    &[InvocationArg::try_from(libname)?],
                 )?;
                 debug("NativeCallbackSupport initialized");
             }
@@ -423,9 +422,7 @@ impl Jvm {
                         Ok(jvm)
                     }
                 }
-                (_, _, _) => Err(J4RsError::JniError(format!(
-                    "Could not initialize the JVM: Error while trying to retrieve JNI functions."
-                ))),
+                (_, _, _) => Err(J4RsError::JniError("Could not initialize the JVM: Error while trying to retrieve JNI functions.".to_string())),
             }
         } else {
             // Use the environment from the Thread Local
@@ -455,7 +452,7 @@ impl Jvm {
         unsafe {
             // Factory invocation - first argument: create a jstring to pass as argument for the class_name
             let class_name_jstring: jstring =
-                jni_utils::global_jobject_from_str(&class_name, self.jni_env)?;
+                jni_utils::global_jobject_from_str(class_name, self.jni_env)?;
 
             // Factory invocation - rest of the arguments: Create a new objectarray of class InvocationArg
             let size = inv_args.len() as i32;
@@ -474,7 +471,7 @@ impl Jvm {
             for i in 0..size {
                 // Create an InvocationArg Java Object
                 let inv_arg_java =
-                    (&inv_args[i as usize]).borrow().as_java_ptr_with_global_ref(self.jni_env)?;
+                    inv_args[i as usize].borrow().as_java_ptr_with_global_ref(self.jni_env)?;
                 // Set it in the array
                 (opt_to_res(cache::get_jni_set_object_array_element())?)(
                     self.jni_env,
@@ -524,7 +521,7 @@ impl Jvm {
         unsafe {
             // Factory invocation - first argument: create a jstring to pass as argument for the class_name
             let class_name_jstring: jstring =
-                jni_utils::global_jobject_from_str(&class_name, self.jni_env)?;
+                jni_utils::global_jobject_from_str(class_name, self.jni_env)?;
 
             // Call the method of the factory that creates a Instance for static calls to methods of class `class_name`.
             // This returns a Instance that acts like a proxy to the Java world.
@@ -561,7 +558,7 @@ impl Jvm {
         unsafe {
             // Factory invocation - first argument: create a jstring to pass as argument for the class_name
             let class_name_jstring: jstring =
-                jni_utils::global_jobject_from_str(&class_name, self.jni_env)?;
+                jni_utils::global_jobject_from_str(class_name, self.jni_env)?;
 
             // Factory invocation - rest of the arguments: Create a new objectarray of class InvocationArg
             let size = inv_args.len() as i32;
@@ -660,7 +657,7 @@ impl Jvm {
         unsafe {
             // Factory invocation - first argument: create a jstring to pass as argument for the class_name
             let class_name_jstring: jstring =
-                jni_utils::global_jobject_from_str(&class_name, jni_env)?;
+                jni_utils::global_jobject_from_str(class_name, jni_env)?;
 
             // Factory invocation - rest of the arguments: Create a new object list of class InvocationArg
             let size = inv_args.len() as i32;
@@ -739,9 +736,9 @@ impl Jvm {
 
         for (key, val) in inv_args.drain() {
             inv_args_results.insert(i, key.try_into());
-            i = i + 1;
+            i += 1;
             inv_args_results.insert(i, val.try_into());
-            i = i + 1;
+            i += 1;
         }
         let inv_args: Result<Vec<InvocationArg>, J4RsError> = inv_args_results
             .into_iter()
@@ -770,10 +767,10 @@ impl Jvm {
         unsafe {
             // Factory invocation - first argument: create a jstring to pass as argument for the key_class_name
             let key_class_name_jstring: jstring =
-                jni_utils::global_jobject_from_str(&key_class_name, jni_env)?;
+                jni_utils::global_jobject_from_str(key_class_name, jni_env)?;
             // Factory invocation - second argument: create a jstring to pass as argument for the value_class_name
             let value_class_name_jstring: jstring =
-                jni_utils::global_jobject_from_str(&value_class_name, jni_env)?;
+                jni_utils::global_jobject_from_str(value_class_name, jni_env)?;
 
             // Factory invocation - rest of the arguments: Create a new object list of class InvocationArg
             let size = inv_args.len() as i32;
@@ -854,7 +851,7 @@ impl Jvm {
         unsafe {
             // First argument: create a jstring to pass as argument for the method_name
             let method_name_jstring: jstring =
-                jni_utils::global_jobject_from_str(&method_name, self.jni_env)?;
+                jni_utils::global_jobject_from_str(method_name, self.jni_env)?;
 
             // Rest of the arguments: Create a new objectarray of class InvocationArg
             let size = inv_args.len() as i32;
@@ -926,7 +923,7 @@ impl Jvm {
         unsafe {
             // First argument: create a jstring to pass as argument for the field_name
             let field_name_jstring: jstring =
-                jni_utils::global_jobject_from_str(&field_name, self.jni_env)?;
+                jni_utils::global_jobject_from_str(field_name, self.jni_env)?;
 
             // Call the method of the instance
             let java_instance = (opt_to_res(cache::get_jni_call_object_method())?)(
@@ -967,7 +964,7 @@ impl Jvm {
             field_name, class_name
         ));
         let i = self.static_class(class_name)?;
-        self.field(&i, &field_name)
+        self.field(&i, field_name)
     }
 
     /// Invokes the method `method_name` of a created `Instance`, passing an array of `InvocationArg`s.
@@ -991,7 +988,7 @@ impl Jvm {
 
             // Second argument: create a jstring to pass as argument for the method_name
             let method_name_jstring: jstring =
-                jni_utils::global_jobject_from_str(&method_name, self.jni_env)?;
+                jni_utils::global_jobject_from_str(method_name, self.jni_env)?;
 
             // Rest of the arguments: Create a new objectarray of class InvocationArg
             let size = inv_args.len() as i32;
@@ -1022,7 +1019,7 @@ impl Jvm {
             }
 
             // Call the method of the instance
-            let _ = (opt_to_res(cache::get_jni_call_void_method())?)(
+            (opt_to_res(cache::get_jni_call_void_method())?)(
                 self.jni_env,
                 instance.jinstance,
                 cache::get_invoke_to_channel_method()?,
@@ -1050,7 +1047,7 @@ impl Jvm {
     /// It returns a Result of `InstanceReceiver` that may be used to get an underlying `Receiver<Instance>`.
     /// The `NativeCallbackToRustChannelSupport` Instance which is passed as argument, will be sending `Instance`s via this Receiver.
     pub fn init_callback_channel(&self, instance: &Instance) -> errors::Result<InstanceReceiver> {
-        debug(&format!("Initializing callback channel"));
+        debug("Initializing callback channel");
         unsafe {
             // Create the channel
             let (sender, rx) = channel();
@@ -1062,7 +1059,7 @@ impl Jvm {
             let address = u64::from_str_radix(&address_string[2..], 16).unwrap();
 
             // Call the method of the instance
-            let _ = (opt_to_res(cache::get_jni_call_void_method())?)(
+            (opt_to_res(cache::get_jni_call_void_method())?)(
                 self.jni_env,
                 instance.jinstance,
                 cache::get_init_callback_channel_method()?,
@@ -1090,7 +1087,7 @@ impl Jvm {
         unsafe {
             // Factory invocation - first argument: create a jstring to pass as argument for the class_name
             let class_name_jstring: jstring =
-                jni_utils::global_jobject_from_str(&class_name, self.jni_env)?;
+                jni_utils::global_jobject_from_str(class_name, self.jni_env)?;
             // Call the method of the factory that creates a Instance for static calls to methods of class `class_name`.
             // This returns a Instance that acts like a proxy to the Java world.
             let java_instance = (opt_to_res(cache::get_jni_call_static_object_method())?)(
@@ -1102,7 +1099,7 @@ impl Jvm {
 
             // First argument: create a jstring to pass as argument for the method_name
             let method_name_jstring: jstring =
-                jni_utils::global_jobject_from_str(&method_name, self.jni_env)?;
+                jni_utils::global_jobject_from_str(method_name, self.jni_env)?;
 
             // Rest of the arguments: Create a new objectarray of class InvocationArg
             let size = inv_args.len() as i32;
@@ -1182,7 +1179,7 @@ impl Jvm {
             // First argument is the jobject that is inside the from_instance
             // Second argument: create a jstring to pass as argument for the to_class
             let to_class_jstring: jstring =
-                jni_utils::global_jobject_from_str(&to_class, self.jni_env)?;
+                jni_utils::global_jobject_from_str(to_class, self.jni_env)?;
 
             // Call the cast method
             let java_instance = (opt_to_res(cache::get_jni_call_static_object_method())?)(
@@ -1251,7 +1248,7 @@ impl Jvm {
 
     /// Consumes the `Jvm` and returns its `JNIEnv`
     pub fn into_raw(self) -> *mut JNIEnv {
-        debug(&format!("Getting the raw JNIEnv from the Jvm"));
+        debug("Getting the raw JNIEnv from the Jvm");
 
         self.jni_env
     }
@@ -1288,7 +1285,9 @@ impl Jvm {
         }
 
         let t_type = TypeId::of::<T>();
-        let to_ret = unsafe {
+        
+
+        unsafe {
             // Call the getClassName method. This returns a localref
             let object_class_name_instance = (opt_to_res(cache::get_jni_call_object_method())?)(
                 self.jni_env,
@@ -1299,8 +1298,7 @@ impl Jvm {
                 object_class_name_instance,
                 self.jni_env,
             )?;
-            let ref class_name =
-                jni_utils::string_from_jobject(object_class_name_instance, self.jni_env)?;
+            let class_name = &(jni_utils::string_from_jobject(object_class_name_instance, self.jni_env)?);
             jni_utils::delete_java_ref(self.jni_env, object_class_name_instance);
             if t_type == TypeId::of::<String>() && JavaClass::String.get_class_str() == class_name {
                 rust_box_from_java_object!(jni_utils::string_from_jobject)
@@ -1368,9 +1366,7 @@ impl Jvm {
             } else {
                 Ok(Box::new(self.to_rust_deserialized(instance)?))
             }
-        };
-
-        to_ret
+        }
     }
 
     /// Returns the Rust representation of the provided instance
@@ -1397,7 +1393,7 @@ impl Jvm {
             debug("Transforming jstring to rust String");
             let global_json_instance =
                 jni_utils::create_global_ref_from_local_ref(json_instance, self.jni_env)?;
-            let json = jni_utils::jstring_to_rust_string(&self, global_json_instance as jstring)?;
+            let json = jni_utils::jstring_to_rust_string(self, global_json_instance as jstring)?;
             jni_utils::delete_java_ref(self.jni_env, global_json_instance);
             Self::do_return(self.jni_env, serde_json::from_str(&json)?)
         }
@@ -1414,10 +1410,8 @@ impl Jvm {
             for repo in get_maven_settings().repos.into_iter() {
                 let instance = self.create_instance(
                     "org.astonbitecode.j4rs.api.deploy.SimpleMavenDeployer",
-                    &vec![
-                        InvocationArg::try_from(repo.uri)?,
-                        InvocationArg::try_from(&maven_artifact.base)?,
-                    ],
+                    &[InvocationArg::try_from(repo.uri)?,
+                        InvocationArg::try_from(&maven_artifact.base)?],
                 )?;
 
                 let res = self.invoke(
@@ -1440,13 +1434,13 @@ impl Jvm {
         } else if let Some(local_jar_artifact) = artifact.downcast_ref::<LocalJarArtifact>() {
             let instance = self.create_instance(
                 "org.astonbitecode.j4rs.api.deploy.FileSystemDeployer",
-                &vec![InvocationArg::try_from(&local_jar_artifact.base)?],
+                &[InvocationArg::try_from(&local_jar_artifact.base)?],
             )?;
 
             let _ = self.invoke(
                 &instance,
                 "deploy",
-                &vec![InvocationArg::try_from(&local_jar_artifact.path)?],
+                &[InvocationArg::try_from(&local_jar_artifact.path)?],
             )?;
             Ok(())
         } else {
@@ -1471,7 +1465,7 @@ impl Jvm {
         let default_jassets_path_string = default_jassets_path_buf.to_str().unwrap().to_owned();
 
         // Copy the jassets
-        let ref mut options = fs_extra::dir::CopyOptions::new();
+        let options = &mut fs_extra::dir::CopyOptions::new();
         options.overwrite = true;
         let _ = fs_extra::copy_items(vec![default_jassets_path_string].as_ref(), path, options)?;
 
@@ -1507,12 +1501,12 @@ impl Jvm {
 
     /// Initiates a chain of operations on Instances.
     pub fn chain(&self, instance: &Instance) -> errors::Result<ChainableInstance> {
-        ChainableInstance::new_with_instance_ref(&instance, &self)
+        ChainableInstance::new_with_instance_ref(instance, self)
     }
 
     /// Initiates a chain of operations on Instances.
     pub fn into_chain(&self, instance: Instance) -> ChainableInstance {
-        ChainableInstance::new(instance, &self)
+        ChainableInstance::new(instance, self)
     }
 
     /// Throws an exception in the Java World
@@ -1918,10 +1912,10 @@ impl<'a> JvmBuilder<'a> {
                 vec![default_lib_name]
             };
 
-            let lib_name_opt = if found_libs.len() > 0 {
+            let lib_name_opt = if !found_libs.is_empty() {
                 let a_lib = found_libs[0].clone().replace("lib", "");
 
-                let dot_splitted: Vec<&str> = a_lib.split(".").collect();
+                let dot_splitted: Vec<&str> = a_lib.split('.').collect();
                 let name = dot_splitted[0].to_string();
                 info(&format!(
                     "Passing to the Java world the name of the library to load: {}",
@@ -1945,11 +1939,11 @@ impl<'a> JvmBuilder<'a> {
 
         provisioning::set_maven_settings(&self.maven_settings);
 
-        Jvm::new(&jvm_options, lib_name_opt).and_then(|mut jvm| {
+        Jvm::new(&jvm_options, lib_name_opt).map(|mut jvm| {
             if !self.detach_thread_on_drop {
                 jvm.detach_thread_on_drop(false);
             }
-            Ok(jvm)
+            jvm
         })
     }
 

--- a/rust/src/api_tweaks/generic.rs
+++ b/rust/src/api_tweaks/generic.rs
@@ -16,7 +16,6 @@ use std::path::MAIN_SEPARATOR;
 
 use java_locator::{get_jvm_dyn_lib_file_name, locate_jvm_dyn_library};
 use jni_sys::{jclass, jint, jsize, JNIEnv, JavaVM};
-use libloading;
 
 use crate::{errors, utils};
 

--- a/rust/src/async_api/mod.rs
+++ b/rust/src/async_api/mod.rs
@@ -41,7 +41,7 @@ impl Jvm {
         // Create the channel
         let (sender, rx) = oneshot::channel::<errors::Result<Instance>>();
         unsafe {
-            Self::handle_channel_sender(self, sender, &instance, &method_name, inv_args.as_ref())?;
+            Self::handle_channel_sender(self, sender, instance, method_name, inv_args)?;
         }
         // Create and return the Instance
         let instance = rx.await?;
@@ -91,7 +91,7 @@ impl Jvm {
 
             // Second argument: create a jstring to pass as argument for the method_name
             let method_name_jstring: jstring =
-                jni_utils::global_jobject_from_str(&method_name, s.jni_env)?;
+                jni_utils::global_jobject_from_str(method_name, s.jni_env)?;
 
             // Rest of the arguments: Create a new objectarray of class InvocationArg
             let size = inv_args.len() as i32;
@@ -122,7 +122,7 @@ impl Jvm {
             }
 
             // Call the method of the instance
-            let _ = (opt_to_res(cache::get_jni_call_void_method())?)(
+            (opt_to_res(cache::get_jni_call_void_method())?)(
                 s.jni_env,
                 instance.jinstance,
                 cache::get_invoke_async_method()?,

--- a/rust/src/cache.rs
+++ b/rust/src/cache.rs
@@ -25,13 +25,13 @@ use crate::errors::opt_to_res;
 use crate::logger::debug;
 use crate::{api_tweaks as tweaks, errors, jni_utils, utils};
 
-pub(crate) const INST_CLASS_NAME: &'static str =
+pub(crate) const INST_CLASS_NAME: &str =
     "org/astonbitecode/j4rs/api/instantiation/NativeInstantiationImpl";
-pub(crate) const UTILS_CLASS_NAME: &'static str = "org/astonbitecode/j4rs/utils/Utils";
-pub(crate) const INVO_BASE_NAME: &'static str = "org/astonbitecode/j4rs/api/InstanceBase";
-pub(crate) const INVO_IFACE_NAME: &'static str = "org/astonbitecode/j4rs/api/Instance";
-pub(crate) const UNKNOWN_FOR_RUST: &'static str = "known_in_java_world";
-pub(crate) const J4RS_ARRAY: &'static str = "org.astonbitecode.j4rs.api.dtos.Array";
+pub(crate) const UTILS_CLASS_NAME: &str = "org/astonbitecode/j4rs/utils/Utils";
+pub(crate) const INVO_BASE_NAME: &str = "org/astonbitecode/j4rs/api/InstanceBase";
+pub(crate) const INVO_IFACE_NAME: &str = "org/astonbitecode/j4rs/api/Instance";
+pub(crate) const UNKNOWN_FOR_RUST: &str = "known_in_java_world";
+pub(crate) const J4RS_ARRAY: &str = "org.astonbitecode.j4rs.api.dtos.Array";
 
 pub(crate) type JniGetMethodId = unsafe extern "system" fn(
     *mut jni_sys::JNIEnv,
@@ -225,8 +225,8 @@ lazy_static! {
 }
 
 thread_local! {
-    pub(crate) static JNI_ENV: RefCell<Option<*mut JNIEnv>> = RefCell::new(None);
-    pub(crate) static ACTIVE_JVMS: RefCell<i32> = RefCell::new(0);
+    pub(crate) static JNI_ENV: RefCell<Option<*mut JNIEnv>> = const { RefCell::new(None) };
+    pub(crate) static ACTIVE_JVMS: RefCell<i32> = const { RefCell::new(0) };
     pub(crate) static JNI_GET_METHOD_ID: RefCell<Option<JniGetMethodId>> = RefCell::new(None);
     pub(crate) static JNI_GET_STATIC_METHOD_ID: RefCell<Option<JniGetStaticMethodId>> = RefCell::new(None);
     pub(crate) static JNI_NEW_OBJECT: RefCell<Option<JniNewObject>> = RefCell::new(None);
@@ -257,86 +257,86 @@ thread_local! {
     pub(crate) static JNI_THROW_NEW: RefCell<Option<JniThrowNew>> = RefCell::new(None);
     pub(crate) static JNI_IS_SAME_OBJECT: RefCell<Option<JniIsSameObject>> = RefCell::new(None);
     // This is the Utils class.
-    pub(crate) static UTILS_CLASS: RefCell<Option<jclass>> = RefCell::new(None);
+    pub(crate) static UTILS_CLASS: RefCell<Option<jclass>> = const { RefCell::new(None) };
     // Utils throwableToString method
-    pub(crate) static UTILS_THROWABLE_TO_STRING_METHOD: RefCell<Option<jmethodID>> = RefCell::new(None);
+    pub(crate) static UTILS_THROWABLE_TO_STRING_METHOD: RefCell<Option<jmethodID>> = const { RefCell::new(None) };
     // This is the factory class. It creates instances using reflection. Currently the `NativeInstantiationImpl`.
-    pub(crate) static FACTORY_CLASS: RefCell<Option<jclass>> = RefCell::new(None);
+    pub(crate) static FACTORY_CLASS: RefCell<Option<jclass>> = const { RefCell::new(None) };
     // The constructor method of the `NativeInstantiationImpl`.
-    pub(crate) static FACTORY_CONSTRUCTOR_METHOD: RefCell<Option<jmethodID>> = RefCell::new(None);
+    pub(crate) static FACTORY_CONSTRUCTOR_METHOD: RefCell<Option<jmethodID>> = const { RefCell::new(None) };
     // The method id of the `instantiate` method of the `NativeInstantiation`.
-    pub(crate) static FACTORY_INSTANTIATE_METHOD: RefCell<Option<jmethodID>> = RefCell::new(None);
+    pub(crate) static FACTORY_INSTANTIATE_METHOD: RefCell<Option<jmethodID>> = const { RefCell::new(None) };
     // The method id of the `createForStatic` method of the `NativeInstantiation`.
-    pub(crate) static FACTORY_CREATE_FOR_STATIC_METHOD: RefCell<Option<jmethodID>> = RefCell::new(None);
+    pub(crate) static FACTORY_CREATE_FOR_STATIC_METHOD: RefCell<Option<jmethodID>> = const { RefCell::new(None) };
     // The method id of the `createJavaArray` method of the `NativeInstantiation`.
-    pub(crate) static FACTORY_CREATE_JAVA_ARRAY_METHOD: RefCell<Option<jmethodID>> = RefCell::new(None);
+    pub(crate) static FACTORY_CREATE_JAVA_ARRAY_METHOD: RefCell<Option<jmethodID>> = const { RefCell::new(None) };
     // The method id of the `createJavaList` method of the `NativeInstantiation`.
-    pub(crate) static FACTORY_CREATE_JAVA_LIST_METHOD: RefCell<Option<jmethodID>> = RefCell::new(None);
+    pub(crate) static FACTORY_CREATE_JAVA_LIST_METHOD: RefCell<Option<jmethodID>> = const { RefCell::new(None) };
     // The method id of the `createJavaMap` method of the `NativeInstantiation`.
-    pub(crate) static FACTORY_CREATE_JAVA_MAP_METHOD: RefCell<Option<jmethodID>> = RefCell::new(None);
+    pub(crate) static FACTORY_CREATE_JAVA_MAP_METHOD: RefCell<Option<jmethodID>> = const { RefCell::new(None) };
     // The `Instance` class.
     // This is optional because it exists only in Android for Java7 compatibility
     // because Java7 does not support static method implementations in interfaces.
-    pub(crate) static JAVA_INSTANCE_BASE_CLASS: RefCell<Option<jclass>> = RefCell::new(None);
+    pub(crate) static JAVA_INSTANCE_BASE_CLASS: RefCell<Option<jclass>> = const { RefCell::new(None) };
     // The `Instance` class.
-    pub(crate) static JAVA_INSTANCE_CLASS: RefCell<Option<jclass>> = RefCell::new(None);
+    pub(crate) static JAVA_INSTANCE_CLASS: RefCell<Option<jclass>> = const { RefCell::new(None) };
     // The Java class for the `InvocationArg`.
-    pub(crate) static INVOCATION_ARG_CLASS: RefCell<Option<jclass>> = RefCell::new(None);
+    pub(crate) static INVOCATION_ARG_CLASS: RefCell<Option<jclass>> = const { RefCell::new(None) };
     // The invoke method
-    pub(crate) static INVOKE_METHOD: RefCell<Option<jmethodID>> = RefCell::new(None);
+    pub(crate) static INVOKE_METHOD: RefCell<Option<jmethodID>> = const { RefCell::new(None) };
     // The invoke static method
-    pub(crate) static INVOKE_STATIC_METHOD: RefCell<Option<jmethodID>> = RefCell::new(None);
+    pub(crate) static INVOKE_STATIC_METHOD: RefCell<Option<jmethodID>> = const { RefCell::new(None) };
     // The invoke to channel method
-    pub(crate) static INVOKE_TO_CHANNEL_METHOD: RefCell<Option<jmethodID>> = RefCell::new(None);
+    pub(crate) static INVOKE_TO_CHANNEL_METHOD: RefCell<Option<jmethodID>> = const { RefCell::new(None) };
     // The method that invokes a Java method that returns Future
-    pub(crate) static INVOKE_ASYNC_METHOD: RefCell<Option<jmethodID>> = RefCell::new(None);
+    pub(crate) static INVOKE_ASYNC_METHOD: RefCell<Option<jmethodID>> = const { RefCell::new(None) };
     // The init callback channel method
-    pub(crate) static INIT_CALLBACK_CHANNEL_METHOD: RefCell<Option<jmethodID>> = RefCell::new(None);
+    pub(crate) static INIT_CALLBACK_CHANNEL_METHOD: RefCell<Option<jmethodID>> = const { RefCell::new(None) };
     // The field method
-    pub(crate) static FIELD_METHOD: RefCell<Option<jmethodID>> = RefCell::new(None);
-    pub(crate) static CLASS_TO_INVOKE_CLONE_AND_CAST: RefCell<Option<jclass>> = RefCell::new(None);
+    pub(crate) static FIELD_METHOD: RefCell<Option<jmethodID>> = const { RefCell::new(None) };
+    pub(crate) static CLASS_TO_INVOKE_CLONE_AND_CAST: RefCell<Option<jclass>> = const { RefCell::new(None) };
     // The clone method
-    pub(crate) static CLONE_STATIC_METHOD: RefCell<Option<jmethodID>> = RefCell::new(None);
+    pub(crate) static CLONE_STATIC_METHOD: RefCell<Option<jmethodID>> = const { RefCell::new(None) };
     // The cast method
-    pub(crate) static CAST_STATIC_METHOD: RefCell<Option<jmethodID>> = RefCell::new(None);
+    pub(crate) static CAST_STATIC_METHOD: RefCell<Option<jmethodID>> = const { RefCell::new(None) };
     // The get json method
-    pub(crate) static GET_JSON_METHOD: RefCell<Option<jmethodID>> = RefCell::new(None);
+    pub(crate) static GET_JSON_METHOD: RefCell<Option<jmethodID>> = const { RefCell::new(None) };
     // The get checkEquals method
-    pub(crate) static CHECK_EQUALS_METHOD: RefCell<Option<jmethodID>> = RefCell::new(None);
+    pub(crate) static CHECK_EQUALS_METHOD: RefCell<Option<jmethodID>> = const { RefCell::new(None) };
     // The get object class name method
-    pub(crate) static GET_OBJECT_CLASS_NAME_METHOD: RefCell<Option<jmethodID>> = RefCell::new(None);
+    pub(crate) static GET_OBJECT_CLASS_NAME_METHOD: RefCell<Option<jmethodID>> = const { RefCell::new(None) };
     // The get object method
-    pub(crate) static GET_OBJECT_METHOD: RefCell<Option<jmethodID>> = RefCell::new(None);
+    pub(crate) static GET_OBJECT_METHOD: RefCell<Option<jmethodID>> = const { RefCell::new(None) };
     // The invstatic ocation argument constructor method for objects created by Java
-    pub(crate) static INV_ARG_JAVA_CONSTRUCTOR_METHOD: RefCell<Option<jmethodID>> = RefCell::new(None);
+    pub(crate) static INV_ARG_JAVA_CONSTRUCTOR_METHOD: RefCell<Option<jmethodID>> = const { RefCell::new(None) };
     // The invstatic ocation argument constructor method for objects created by Rust
-    pub(crate) static INV_ARG_RUST_CONSTRUCTOR_METHOD: RefCell<Option<jmethodID>> = RefCell::new(None);
+    pub(crate) static INV_ARG_RUST_CONSTRUCTOR_METHOD: RefCell<Option<jmethodID>> = const { RefCell::new(None) };
     // The invstatic ocation argument constructor method for objects of Basic type created by Rust
-    pub(crate) static INV_ARG_BASIC_RUST_CONSTRUCTOR_METHOD: RefCell<Option<jmethodID>> = RefCell::new(None);
+    pub(crate) static INV_ARG_BASIC_RUST_CONSTRUCTOR_METHOD: RefCell<Option<jmethodID>> = const { RefCell::new(None) };
     // Basic types definitions
-    pub(crate) static INTEGER_CONSTRUCTOR_METHOD: RefCell<Option<jmethodID>> = RefCell::new(None);
-    pub(crate) static INTEGER_TO_INT_METHOD: RefCell<Option<jmethodID>> = RefCell::new(None);
-    pub(crate) static INTEGER_CLASS: RefCell<Option<jclass>> = RefCell::new(None);
-    pub(crate) static LONG_CONSTRUCTOR_METHOD: RefCell<Option<jmethodID>> = RefCell::new(None);
-    pub(crate) static LONG_TO_LONG_METHOD: RefCell<Option<jmethodID>> = RefCell::new(None);
-    pub(crate) static LONG_CLASS: RefCell<Option<jclass>> = RefCell::new(None);
-    pub(crate) static SHORT_CONSTRUCTOR_METHOD: RefCell<Option<jmethodID>> = RefCell::new(None);
-    pub(crate) static SHORT_TO_SHORT_METHOD: RefCell<Option<jmethodID>> = RefCell::new(None);
-    pub(crate) static SHORT_CLASS: RefCell<Option<jclass>> = RefCell::new(None);
-    pub(crate) static CHARACTER_CONSTRUCTOR_METHOD: RefCell<Option<jmethodID>> = RefCell::new(None);
-    pub(crate) static CHARACTER_TO_CHAR_METHOD: RefCell<Option<jmethodID>> = RefCell::new(None);
-    pub(crate) static CHARACTER_CLASS: RefCell<Option<jclass>> = RefCell::new(None);
-    pub(crate) static BYTE_CONSTRUCTOR_METHOD: RefCell<Option<jmethodID>> = RefCell::new(None);
-    pub(crate) static BYTE_TO_BYTE_METHOD: RefCell<Option<jmethodID>> = RefCell::new(None);
-    pub(crate) static BYTE_CLASS: RefCell<Option<jclass>> = RefCell::new(None);
-    pub(crate) static FLOAT_CONSTRUCTOR_METHOD: RefCell<Option<jmethodID>> = RefCell::new(None);
-    pub(crate) static FLOAT_TO_FLOAT_METHOD: RefCell<Option<jmethodID>> = RefCell::new(None);
-    pub(crate) static FLOAT_CLASS: RefCell<Option<jclass>> = RefCell::new(None);
-    pub(crate) static DOUBLE_CONSTRUCTOR_METHOD: RefCell<Option<jmethodID>> = RefCell::new(None);
-    pub(crate) static DOUBLE_TO_DOUBLE_METHOD: RefCell<Option<jmethodID>> = RefCell::new(None);
-    pub(crate) static DOUBLE_CLASS: RefCell<Option<jclass>> = RefCell::new(None);
-    pub(crate) static INVOCATION_EXCEPTION_CLASS: RefCell<Option<jclass>> = RefCell::new(None);
-    pub(crate) static STRING_CLASS: RefCell<Option<jclass>> = RefCell::new(None);
+    pub(crate) static INTEGER_CONSTRUCTOR_METHOD: RefCell<Option<jmethodID>> = const { RefCell::new(None) };
+    pub(crate) static INTEGER_TO_INT_METHOD: RefCell<Option<jmethodID>> = const { RefCell::new(None) };
+    pub(crate) static INTEGER_CLASS: RefCell<Option<jclass>> = const { RefCell::new(None) };
+    pub(crate) static LONG_CONSTRUCTOR_METHOD: RefCell<Option<jmethodID>> = const { RefCell::new(None) };
+    pub(crate) static LONG_TO_LONG_METHOD: RefCell<Option<jmethodID>> = const { RefCell::new(None) };
+    pub(crate) static LONG_CLASS: RefCell<Option<jclass>> = const { RefCell::new(None) };
+    pub(crate) static SHORT_CONSTRUCTOR_METHOD: RefCell<Option<jmethodID>> = const { RefCell::new(None) };
+    pub(crate) static SHORT_TO_SHORT_METHOD: RefCell<Option<jmethodID>> = const { RefCell::new(None) };
+    pub(crate) static SHORT_CLASS: RefCell<Option<jclass>> = const { RefCell::new(None) };
+    pub(crate) static CHARACTER_CONSTRUCTOR_METHOD: RefCell<Option<jmethodID>> = const { RefCell::new(None) };
+    pub(crate) static CHARACTER_TO_CHAR_METHOD: RefCell<Option<jmethodID>> = const { RefCell::new(None) };
+    pub(crate) static CHARACTER_CLASS: RefCell<Option<jclass>> = const { RefCell::new(None) };
+    pub(crate) static BYTE_CONSTRUCTOR_METHOD: RefCell<Option<jmethodID>> = const { RefCell::new(None) };
+    pub(crate) static BYTE_TO_BYTE_METHOD: RefCell<Option<jmethodID>> = const { RefCell::new(None) };
+    pub(crate) static BYTE_CLASS: RefCell<Option<jclass>> = const { RefCell::new(None) };
+    pub(crate) static FLOAT_CONSTRUCTOR_METHOD: RefCell<Option<jmethodID>> = const { RefCell::new(None) };
+    pub(crate) static FLOAT_TO_FLOAT_METHOD: RefCell<Option<jmethodID>> = const { RefCell::new(None) };
+    pub(crate) static FLOAT_CLASS: RefCell<Option<jclass>> = const { RefCell::new(None) };
+    pub(crate) static DOUBLE_CONSTRUCTOR_METHOD: RefCell<Option<jmethodID>> = const { RefCell::new(None) };
+    pub(crate) static DOUBLE_TO_DOUBLE_METHOD: RefCell<Option<jmethodID>> = const { RefCell::new(None) };
+    pub(crate) static DOUBLE_CLASS: RefCell<Option<jclass>> = const { RefCell::new(None) };
+    pub(crate) static INVOCATION_EXCEPTION_CLASS: RefCell<Option<jclass>> = const { RefCell::new(None) };
+    pub(crate) static STRING_CLASS: RefCell<Option<jclass>> = const { RefCell::new(None) };
 }
 
 macro_rules! get_cached {
@@ -375,10 +375,7 @@ pub(crate) fn remove_active_jvm() -> i32 {
 
 pub(crate) fn get_thread_local_env_opt() -> Option<*mut JNIEnv> {
     JNI_ENV.with(
-        |existing_jni_env_opt| match *existing_jni_env_opt.borrow() {
-            Some(env) => Some(env),
-            None => None,
-        },
+        |existing_jni_env_opt| (*existing_jni_env_opt.borrow()),
     )
 }
 
@@ -392,9 +389,7 @@ pub(crate) fn set_thread_local_env(jni_env_opt: Option<*mut JNIEnv>) {
 pub(crate) fn get_thread_local_env() -> errors::Result<*mut JNIEnv> {
     match get_thread_local_env_opt() {
         Some(env) => Ok(env),
-        None => Err(errors::J4RsError::JavaError(format!(
-            "Could not find the JNIEnv in the thread local"
-        ))),
+        None => Err(errors::J4RsError::JavaError("Could not find the JNIEnv in the thread local".to_string())),
     }
 }
 
@@ -825,9 +820,7 @@ pub(crate) fn get_utils_exception_to_string_method() -> errors::Result<jmethodID
         UTILS_THROWABLE_TO_STRING_METHOD,
         {
             let env = get_thread_local_env()?;
-            let throwable_to_string_method_signature = format!(
-                "(Ljava/lang/Throwable;)Ljava/lang/String;"
-            );
+            let throwable_to_string_method_signature = "(Ljava/lang/Throwable;)Ljava/lang/String;".to_string();
             let cstr1 = utils::to_c_string("throwableToString");
             let cstr2 = utils::to_c_string(&throwable_to_string_method_signature);
             let j = unsafe {
@@ -1085,9 +1078,9 @@ pub(crate) fn get_java_instance_base_class() -> errors::Result<jclass> {
             let env = get_thread_local_env()?;
 
             let c = tweaks::find_class(env, INVO_BASE_NAME)?;
-            let j = jni_utils::create_global_ref_from_local_ref(c, env)?;
+            
 
-            j
+            jni_utils::create_global_ref_from_local_ref(c, env)?
         },
         set_java_instance_base_class
     )
@@ -1107,9 +1100,9 @@ pub(crate) fn get_java_instance_class() -> errors::Result<jclass> {
             let env = get_thread_local_env()?;
 
             let c = tweaks::find_class(env, INVO_IFACE_NAME)?;
-            let j = jni_utils::create_global_ref_from_local_ref(c, env)?;
+            
 
-            j
+            jni_utils::create_global_ref_from_local_ref(c, env)?
         },
         set_java_instance_class
     )
@@ -1205,7 +1198,7 @@ pub(crate) fn get_invoke_to_channel_method() -> errors::Result<jmethodID> {
             let invoke_to_channel_method_signature =
                 "(JLjava/lang/String;[Lorg/astonbitecode/j4rs/api/dtos/InvocationArg;)V";
             let cstr1 = utils::to_c_string("invokeToChannel");
-            let cstr2 = utils::to_c_string(&invoke_to_channel_method_signature);
+            let cstr2 = utils::to_c_string(invoke_to_channel_method_signature);
             // Get the method ID for the `Instance.invokeToChannel`
             let j = unsafe {
                 (opt_to_res(get_jni_get_method_id())?)(
@@ -1240,7 +1233,7 @@ pub(crate) fn get_invoke_async_method() -> errors::Result<jmethodID> {
             let invoke_to_channel_method_signature =
                 "(JLjava/lang/String;[Lorg/astonbitecode/j4rs/api/dtos/InvocationArg;)V";
             let cstr1 = utils::to_c_string("invokeAsyncToChannel");
-            let cstr2 = utils::to_c_string(&invoke_to_channel_method_signature);
+            let cstr2 = utils::to_c_string(invoke_to_channel_method_signature);
             // Get the method ID for the `Instance.invokeToChannel`
             let j = unsafe {
                 (opt_to_res(get_jni_get_method_id())?)(
@@ -1274,7 +1267,7 @@ pub(crate) fn get_init_callback_channel_method() -> errors::Result<jmethodID> {
 
             let init_callback_channel_method_signature = "(J)V";
             let cstr1 = utils::to_c_string("initializeCallbackChannel");
-            let cstr2 = utils::to_c_string(&init_callback_channel_method_signature);
+            let cstr2 = utils::to_c_string(init_callback_channel_method_signature);
             // Get the method ID for the `Instance.initializeCallbackChannel`
             let j = unsafe {
                 (opt_to_res(get_jni_get_method_id())?)(
@@ -1414,7 +1407,7 @@ pub(crate) fn get_get_json_method() -> errors::Result<jmethodID> {
 
             let get_json_method_signature = "()Ljava/lang/String;";
             let cstr1 = utils::to_c_string("getJson");
-            let cstr2 = utils::to_c_string(get_json_method_signature.as_ref());
+            let cstr2 = utils::to_c_string(get_json_method_signature);
 
             // Get the method ID for the `Instance.getJson`
             let j = unsafe {
@@ -1484,7 +1477,7 @@ pub(crate) fn get_get_object_class_name_method() -> errors::Result<jmethodID> {
 
             let get_object_class_name_method_signature = "()Ljava/lang/String;";
             let cstr1 = utils::to_c_string("getObjectClassName");
-            let cstr2 = utils::to_c_string(get_object_class_name_method_signature.as_ref());
+            let cstr2 = utils::to_c_string(get_object_class_name_method_signature);
 
             // Get the method ID for the `Instance.getObjectClass`
             let j = unsafe {
@@ -1519,7 +1512,7 @@ pub(crate) fn get_get_object_method() -> errors::Result<jmethodID> {
 
             let get_object_method_signature = "()Ljava/lang/Object;";
             let cstr1 = utils::to_c_string("getObject");
-            let cstr2 = utils::to_c_string(get_object_method_signature.as_ref());
+            let cstr2 = utils::to_c_string(get_object_method_signature);
 
             // Get the method ID for the `Instance.getObject`
             let j = unsafe {
@@ -1618,7 +1611,7 @@ pub(crate) fn get_inv_arg_basic_rust_constructor_method() -> errors::Result<jmet
             let inv_arg_basic_rust_constructor_method_signature =
                 "(Ljava/lang/String;Ljava/lang/Object;)V";
             let cstr1 = utils::to_c_string("<init>");
-            let cstr2 = utils::to_c_string(&inv_arg_basic_rust_constructor_method_signature);
+            let cstr2 = utils::to_c_string(inv_arg_basic_rust_constructor_method_signature);
             let j = unsafe {
                 (opt_to_res(get_jni_get_method_id())?)(
                     env,
@@ -1651,13 +1644,13 @@ pub(crate) fn get_class_to_invoke_clone_and_cast() -> errors::Result<jclass> {
             // The java_instance_base_class is used because of Java7 compatibility issues in Android.
             // In Java8 and later, the static implementation in the interfaces is used. This is not supported in Java7
             // and there is a base class created for this reason.
-            let j = if cfg!(target_os = "android") {
+            
+
+            if cfg!(target_os = "android") {
                 get_java_instance_base_class()?
             } else {
                 get_java_instance_class()?
-            };
-
-            j
+            }
         },
         set_class_to_invoke_clone_and_cast
     )
@@ -1698,7 +1691,7 @@ pub(crate) fn get_integer_constructor_method() -> errors::Result<jmethodID> {
 
             let constructor_signature = "(I)V";
             let cstr1 = utils::to_c_string("<init>");
-            let cstr2 = utils::to_c_string(&constructor_signature);
+            let cstr2 = utils::to_c_string(constructor_signature);
             let j = unsafe {
                 (opt_to_res(get_jni_get_method_id())?)(env, get_integer_class()?, cstr1, cstr2)
             };
@@ -1726,7 +1719,7 @@ pub(crate) fn get_integer_to_int_method() -> errors::Result<jmethodID> {
 
             let to_int_signature = "()I";
             let cstr1 = utils::to_c_string("intValue");
-            let cstr2 = utils::to_c_string(&to_int_signature);
+            let cstr2 = utils::to_c_string(to_int_signature);
             let j = unsafe {
                 (opt_to_res(get_jni_get_method_id())?)(env, get_integer_class()?, cstr1, cstr2)
             };
@@ -1794,7 +1787,7 @@ pub(crate) fn get_long_constructor_method() -> errors::Result<jmethodID> {
 
             let constructor_signature = "(J)V";
             let cstr1 = utils::to_c_string("<init>");
-            let cstr2 = utils::to_c_string(&constructor_signature);
+            let cstr2 = utils::to_c_string(constructor_signature);
             let j = unsafe {
                 (opt_to_res(get_jni_get_method_id())?)(env, get_long_class()?, cstr1, cstr2)
             };
@@ -1822,7 +1815,7 @@ pub(crate) fn get_long_to_long_method() -> errors::Result<jmethodID> {
 
             let signature = "()J";
             let cstr1 = utils::to_c_string("longValue");
-            let cstr2 = utils::to_c_string(&signature);
+            let cstr2 = utils::to_c_string(signature);
             let j = unsafe {
                 (opt_to_res(get_jni_get_method_id())?)(env, get_long_class()?, cstr1, cstr2)
             };
@@ -1870,7 +1863,7 @@ pub(crate) fn get_short_constructor_method() -> errors::Result<jmethodID> {
 
             let constructor_signature = "(S)V";
             let cstr1 = utils::to_c_string("<init>");
-            let cstr2 = utils::to_c_string(&constructor_signature);
+            let cstr2 = utils::to_c_string(constructor_signature);
             let j = unsafe {
                 (opt_to_res(get_jni_get_method_id())?)(env, get_short_class()?, cstr1, cstr2)
             };
@@ -1898,7 +1891,7 @@ pub(crate) fn get_short_to_short_method() -> errors::Result<jmethodID> {
 
             let signature = "()S";
             let cstr1 = utils::to_c_string("shortValue");
-            let cstr2 = utils::to_c_string(&signature);
+            let cstr2 = utils::to_c_string(signature);
             let j = unsafe {
                 (opt_to_res(get_jni_get_method_id())?)(env, get_short_class()?, cstr1, cstr2)
             };
@@ -1946,7 +1939,7 @@ pub(crate) fn get_character_constructor_method() -> errors::Result<jmethodID> {
 
             let constructor_signature = "(C)V";
             let cstr1 = utils::to_c_string("<init>");
-            let cstr2 = utils::to_c_string(&constructor_signature);
+            let cstr2 = utils::to_c_string(constructor_signature);
             let j = unsafe {
                 (opt_to_res(get_jni_get_method_id())?)(env, get_character_class()?, cstr1, cstr2)
             };
@@ -1974,7 +1967,7 @@ pub(crate) fn get_character_to_char_method() -> errors::Result<jmethodID> {
 
             let signature = "()C";
             let cstr1 = utils::to_c_string("charValue");
-            let cstr2 = utils::to_c_string(&signature);
+            let cstr2 = utils::to_c_string(signature);
             let j = unsafe {
                 (opt_to_res(get_jni_get_method_id())?)(env, get_character_class()?, cstr1, cstr2)
             };
@@ -2022,7 +2015,7 @@ pub(crate) fn get_byte_constructor_method() -> errors::Result<jmethodID> {
 
             let constructor_signature = "(B)V";
             let cstr1 = utils::to_c_string("<init>");
-            let cstr2 = utils::to_c_string(&constructor_signature);
+            let cstr2 = utils::to_c_string(constructor_signature);
             let j = unsafe {
                 (opt_to_res(get_jni_get_method_id())?)(env, get_byte_class()?, cstr1, cstr2)
             };
@@ -2050,7 +2043,7 @@ pub(crate) fn get_byte_to_byte_method() -> errors::Result<jmethodID> {
 
             let signature = "()B";
             let cstr1 = utils::to_c_string("byteValue");
-            let cstr2 = utils::to_c_string(&signature);
+            let cstr2 = utils::to_c_string(signature);
             let j = unsafe {
                 (opt_to_res(get_jni_get_method_id())?)(env, get_byte_class()?, cstr1, cstr2)
             };
@@ -2102,7 +2095,7 @@ pub(crate) fn get_float_constructor_method() -> errors::Result<jmethodID> {
 
             let constructor_signature = "(F)V";
             let cstr1 = utils::to_c_string("<init>");
-            let cstr2 = utils::to_c_string(&constructor_signature);
+            let cstr2 = utils::to_c_string(constructor_signature);
             let j = unsafe {
                 (opt_to_res(get_jni_get_method_id())?)(env, get_float_class()?, cstr1, cstr2)
             };
@@ -2132,7 +2125,7 @@ pub(crate) fn get_float_to_float_method() -> errors::Result<jmethodID> {
 
             let signature = "()F";
             let cstr1 = utils::to_c_string("floatValue");
-            let cstr2 = utils::to_c_string(&signature);
+            let cstr2 = utils::to_c_string(signature);
             let j = unsafe {
                 (opt_to_res(get_jni_get_method_id())?)(env, get_float_class()?, cstr1, cstr2)
             };
@@ -2184,7 +2177,7 @@ pub(crate) fn get_double_constructor_method() -> errors::Result<jmethodID> {
 
             let constructor_signature = "(D)V";
             let cstr1 = utils::to_c_string("<init>");
-            let cstr2 = utils::to_c_string(&constructor_signature);
+            let cstr2 = utils::to_c_string(constructor_signature);
             let j = unsafe {
                 (opt_to_res(get_jni_get_method_id())?)(env, get_double_class()?, cstr1, cstr2)
             };
@@ -2214,7 +2207,7 @@ pub(crate) fn get_double_to_double_method() -> errors::Result<jmethodID> {
 
             let signature = "()D";
             let cstr1 = utils::to_c_string("doubleValue");
-            let cstr2 = utils::to_c_string(&signature);
+            let cstr2 = utils::to_c_string(signature);
             let j = unsafe {
                 (opt_to_res(get_jni_get_method_id())?)(env, get_double_class()?, cstr1, cstr2)
             };

--- a/rust/src/errors.rs
+++ b/rust/src/errors.rs
@@ -29,9 +29,7 @@ use futures::channel::oneshot::Canceled;
 pub type Result<T> = result::Result<T, J4RsError>;
 
 pub(crate) fn opt_to_res<T>(opt: Option<T>) -> Result<T> {
-    opt.ok_or(J4RsError::RustError(format!(
-        "Option was found None while converting to result"
-    )))
+    opt.ok_or(J4RsError::RustError("Option was found None while converting to result".to_string()))
 }
 
 #[allow(unused)]
@@ -56,11 +54,11 @@ pub enum J4RsError {
 impl fmt::Display for J4RsError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            &J4RsError::GeneralError(ref message) => write!(f, "{}", message),
-            &J4RsError::JavaError(ref message) => write!(f, "{}", message),
-            &J4RsError::JniError(ref message) => write!(f, "{}", message),
-            &J4RsError::RustError(ref message) => write!(f, "{}", message),
-            &J4RsError::ParseError(ref message) => write!(f, "{}", message),
+            J4RsError::GeneralError(message) => write!(f, "{}", message),
+            J4RsError::JavaError(message) => write!(f, "{}", message),
+            J4RsError::JniError(message) => write!(f, "{}", message),
+            J4RsError::RustError(message) => write!(f, "{}", message),
+            J4RsError::ParseError(message) => write!(f, "{}", message),
             &J4RsError::Timeout => write!(f, "Timeout"),
         }
     }

--- a/rust/src/jfx.rs
+++ b/rust/src/jfx.rs
@@ -83,7 +83,7 @@ impl JavaFxSupport for Jvm {
         let event_type_instance = self.static_class_field(&event_class, &field)?;
 
         self.invoke(
-            &instance,
+            instance,
             "addEventHandler",
             &[
                 InvocationArg::try_from(event_type_instance)?,
@@ -100,7 +100,7 @@ impl JavaFxSupport for Jvm {
         let j4rs_event_handler = self.create_instance(CLASS_J4RS_EVENT_HANDLER, InvocationArg::empty())?;
         let action_channel = self.init_callback_channel(&j4rs_event_handler)?;
         self.invoke(
-            &stage,
+            stage,
             "setOnCloseRequest",
             &[InvocationArg::try_from(j4rs_event_handler)?],
         )?;
@@ -160,7 +160,7 @@ impl JavaFxSupport for Jvm {
     }
 
     fn load_fxml(&self, path: &PathBuf, stage: &Instance) -> errors::Result<FxController> {
-        let cloned = self.clone_instance(&stage)?;
+        let cloned = self.clone_instance(stage)?;
         let path_str = opt_to_res(path.to_str())?;
         let controller = self.invoke_static(
             CLASS_J4RS_FXML_LOADER,

--- a/rust/src/jni_utils.rs
+++ b/rust/src/jni_utils.rs
@@ -35,9 +35,9 @@ pub(crate) fn invocation_arg_jobject_from_rust_serialized(
             _s @ &InvocationArg::Java { .. } | _s @ &InvocationArg::RustBasic { .. } => {
                 panic!("Called invocation_arg_jobject_from_rust_serialized for an InvocationArg that contains an object. Please consider opening a bug to the developers.")
             }
-            &InvocationArg::Rust {
-                ref class_name,
-                ref json,
+            InvocationArg::Rust {
+                class_name,
+                json,
                 ..
             } => {
                 debug(&format!(
@@ -91,9 +91,9 @@ pub(crate) fn invocation_arg_jobject_from_rust_basic(
             _s @ &InvocationArg::Rust { .. } => {
                 panic!("Called invocation_arg_jobject_from_rust_basic for an InvocationArg that contains a serialized object. Please consider opening a bug to the developers.")
             }
-            &InvocationArg::RustBasic {
-                ref class_name,
-                ref instance,
+            InvocationArg::RustBasic {
+                class_name,
+                instance,
                 ..
             } => {
                 debug(&format!(
@@ -275,7 +275,7 @@ pub(crate) fn global_jobject_from_str(
 
 pub(crate) fn global_jobject_from_i8(a: &i8, jni_env: *mut JNIEnv) -> errors::Result<jobject> {
     unsafe {
-        let tmp = a.clone() as *const i8;
+        let tmp = *a as *const i8;
         let o = (opt_to_res(cache::get_jni_new_object())?)(
             jni_env,
             cache::get_byte_class()?,
@@ -303,7 +303,7 @@ pub(crate) unsafe fn i8_from_jobject(obj: jobject, jni_env: *mut JNIEnv) -> erro
 
 pub(crate) fn global_jobject_from_i16(a: &i16, jni_env: *mut JNIEnv) -> errors::Result<jobject> {
     unsafe {
-        let tmp = a.clone() as *const i16;
+        let tmp = *a as *const i16;
         let o = (opt_to_res(cache::get_jni_new_object())?)(
             jni_env,
             cache::get_short_class()?,
@@ -316,7 +316,7 @@ pub(crate) fn global_jobject_from_i16(a: &i16, jni_env: *mut JNIEnv) -> errors::
 
 pub(crate) fn global_jobject_from_u16(a: &u16, jni_env: *mut JNIEnv) -> errors::Result<jobject> {
     unsafe {
-        let tmp = a.clone() as *const u16;
+        let tmp = *a as *const u16;
         let o = (opt_to_res(cache::get_jni_new_object())?)(
             jni_env,
             cache::get_character_class()?,
@@ -359,7 +359,7 @@ pub(crate) unsafe fn u16_from_jobject(obj: jobject, jni_env: *mut JNIEnv) -> err
 
 pub(crate) fn global_jobject_from_i32(a: &i32, jni_env: *mut JNIEnv) -> errors::Result<jobject> {
     unsafe {
-        let tmp = a.clone() as *const i32;
+        let tmp = *a as *const i32;
         let o = (opt_to_res(cache::get_jni_new_object())?)(
             jni_env,
             cache::get_integer_class()?,
@@ -387,7 +387,7 @@ pub(crate) unsafe fn i32_from_jobject(obj: jobject, jni_env: *mut JNIEnv) -> err
 
 pub(crate) fn global_jobject_from_i64(a: &i64, jni_env: *mut JNIEnv) -> errors::Result<jobject> {
     unsafe {
-        let tmp = a.clone();
+        let tmp = *a;
         let o = (opt_to_res(cache::get_jni_new_object())?)(
             jni_env,
             cache::get_long_class()?,
@@ -414,7 +414,7 @@ pub(crate) unsafe fn i64_from_jobject(obj: jobject, jni_env: *mut JNIEnv) -> err
 }
 
 pub(crate) fn global_jobject_from_f32(a: &f32, jni_env: *mut JNIEnv) -> errors::Result<jobject> {
-    let tmp = a.clone();
+    let tmp = *a;
     unsafe {
         let o = (opt_to_res(cache::get_jni_new_object())?)(
             jni_env,
@@ -442,7 +442,7 @@ pub(crate) unsafe fn f32_from_jobject(obj: jobject, jni_env: *mut JNIEnv) -> err
 }
 
 pub(crate) fn global_jobject_from_f64(a: &f64, jni_env: *mut JNIEnv) -> errors::Result<jobject> {
-    let tmp = a.clone();
+    let tmp = *a;
     unsafe {
         let o = (opt_to_res(cache::get_jni_new_object())?)(
             jni_env,

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -386,12 +386,12 @@ mod lib_unit_tests {
         // Use the clones as arguments
         let invocation_res = jvm.create_instance(
             "org.astonbitecode.j4rs.tests.MyTest",
-            &vec![InvocationArg::from(i1)],
+            &[InvocationArg::from(i1)],
         );
         assert!(invocation_res.is_ok());
         let invocation_res = jvm.create_instance(
             "org.astonbitecode.j4rs.tests.MyTest",
-            &vec![InvocationArg::from(i2)],
+            &[InvocationArg::from(i2)],
         );
         assert!(invocation_res.is_ok());
 
@@ -661,7 +661,7 @@ mod lib_unit_tests {
             let instance = jvm
                 .create_instance("java.lang.String", instantiation_args.as_ref())
                 ?;
-            let ref tid_from_java: String = jvm.to_rust(instance)?;
+            let tid_from_java: &String = &(jvm.to_rust(instance)?);
             assert!(&tid == tid_from_java);
         }
         {
@@ -670,7 +670,7 @@ mod lib_unit_tests {
             let instance = jvm
                 .create_instance("java.lang.String", instantiation_args.as_ref())
                 ?;
-            let ref tid_from_java: String = jvm.to_rust(instance)?;
+            let tid_from_java: &String = &(jvm.to_rust(instance)?);
             assert!(&tid == tid_from_java);
         }
 
@@ -688,7 +688,7 @@ mod lib_unit_tests {
                 let instance = jvm
                     .create_instance("java.lang.String", instantiation_args.as_ref())
                     .unwrap();
-                let ref tid_from_java: String = jvm.to_rust(instance).unwrap();
+                let tid_from_java: &String = &jvm.to_rust(instance).unwrap();
                 assert!(&tid == tid_from_java);
             }
             {
@@ -697,7 +697,7 @@ mod lib_unit_tests {
                 let instance = jvm
                     .create_instance("java.lang.String", instantiation_args.as_ref())
                     .unwrap();
-                let ref tid_from_java: String = jvm.to_rust(instance).unwrap();
+                let tid_from_java: &String = &jvm.to_rust(instance).unwrap();
                 assert!(&tid == tid_from_java);
             }
             true
@@ -807,7 +807,7 @@ mod lib_unit_tests {
             .invoke(
                 &test_instance,
                 "getMyWithArgsList",
-                &vec![InvocationArg::from(arr_instance)],
+                &[InvocationArg::from(arr_instance)],
             )
             ?;
 
@@ -836,7 +836,7 @@ mod lib_unit_tests {
             .invoke(
                 &test_instance,
                 "addInts",
-                &vec![InvocationArg::from(arr_instance)],
+                &[InvocationArg::from(arr_instance)],
             )
             ?;
 
@@ -866,7 +866,7 @@ mod lib_unit_tests {
             .invoke_static(
                 "org.astonbitecode.j4rs.tests.MyTest",
                 "useLongPrimitivesArray",
-                &vec![InvocationArg::from(arr_instance)],
+                &[InvocationArg::from(arr_instance)],
             )
             ?;
 
@@ -879,7 +879,7 @@ mod lib_unit_tests {
         let instance = jvm
             .create_instance(
                 "org.astonbitecode.j4rs.tests.MyTest",
-                &vec![InvocationArg::try_from("string")?],
+                &[InvocationArg::try_from("string")?],
             )
             ?;
 
@@ -888,7 +888,7 @@ mod lib_unit_tests {
             ?
             .invoke(
                 "appendToMyString",
-                &vec![InvocationArg::try_from("_is_appended")?],
+                &[InvocationArg::try_from("_is_appended")?],
             )
             ?
             .invoke("length", InvocationArg::empty())
@@ -908,7 +908,7 @@ mod lib_unit_tests {
         let instance = jvm
             .create_instance(
                 "org.astonbitecode.j4rs.tests.MyTest",
-                &vec![InvocationArg::try_from("string")?],
+                &[InvocationArg::try_from("string")?],
             )
             ?;
 
@@ -916,7 +916,7 @@ mod lib_unit_tests {
             .into_chain(instance)
             .invoke(
                 "appendToMyString",
-                &vec![InvocationArg::try_from("_is_appended")?],
+                &[InvocationArg::try_from("_is_appended")?],
             )
             ?
             .invoke("length", InvocationArg::empty())
@@ -971,7 +971,7 @@ mod lib_unit_tests {
             ?
             .invoke(
                 "println",
-                &vec![InvocationArg::try_from("Hello World")?],
+                &[InvocationArg::try_from("Hello World")?],
             )
             ?
             .collect();
@@ -1019,10 +1019,8 @@ mod lib_unit_tests {
             .invoke(
                 &dummy_map,
                 "put",
-                &vec![
-                    InvocationArg::try_from("three")?,
-                    InvocationArg::try_from(3)?,
-                ],
+                &[InvocationArg::try_from("three")?,
+                    InvocationArg::try_from(3)?],
             )
             ?;
 
@@ -1253,7 +1251,7 @@ mod lib_unit_tests {
             .invoke(
                 &test_instance,
                 "echo",
-                &vec![InvocationArg::try_from(true)?],
+                &[InvocationArg::try_from(true)?],
             )
             ?;
         let _: Box<bool> = jvm.to_rust_boxed(i)?;
@@ -1261,7 +1259,7 @@ mod lib_unit_tests {
             .invoke(
                 &test_instance,
                 "echo",
-                &vec![InvocationArg::try_from(33_i8)?],
+                &[InvocationArg::try_from(33_i8)?],
             )
             ?;
         let _: Box<i8> = jvm.to_rust_boxed(i)?;
@@ -1269,7 +1267,7 @@ mod lib_unit_tests {
             .invoke(
                 &test_instance,
                 "echo",
-                &vec![InvocationArg::try_from(33_i16)?],
+                &[InvocationArg::try_from(33_i16)?],
             )
             ?;
         let _: Box<i16> = jvm.to_rust_boxed(i)?;
@@ -1277,7 +1275,7 @@ mod lib_unit_tests {
             .invoke(
                 &test_instance,
                 "echo",
-                &vec![InvocationArg::try_from(33_i32)?],
+                &[InvocationArg::try_from(33_i32)?],
             )
             ?;
         let _: Box<i32> = jvm.to_rust_boxed(i)?;
@@ -1285,7 +1283,7 @@ mod lib_unit_tests {
             .invoke(
                 &test_instance,
                 "echo",
-                &vec![InvocationArg::try_from(33_i64)?],
+                &[InvocationArg::try_from(33_i64)?],
             )
             ?;
         let _: Box<i64> = jvm.to_rust_boxed(i)?;

--- a/rust/src/provisioning.rs
+++ b/rust/src/provisioning.rs
@@ -13,12 +13,11 @@
 // limitations under the License.
 
 use std::cell::RefCell;
-use std::path::PathBuf;
 
 use crate::utils;
 
-const MAVEN_CENTRAL: &'static str = "MavenCentral::https://repo.maven.apache.org/maven2";
-const OSS_SNAPSHOTS: &'static str = "OssSnapshots::https://oss.sonatype.org/content/repositories/snapshots";
+const MAVEN_CENTRAL: &str = "MavenCentral::https://repo.maven.apache.org/maven2";
+const OSS_SNAPSHOTS: &str = "OssSnapshots::https://oss.sonatype.org/content/repositories/snapshots";
 
 thread_local! {
     static MAVEN_SETTINGS: RefCell<MavenSettings> = RefCell::new(MavenSettings::default());
@@ -54,7 +53,7 @@ impl LocalJarArtifact {
     pub fn new(path: &str) -> LocalJarArtifact {
         LocalJarArtifact {
             base: utils::jassets_path()
-                .unwrap_or(PathBuf::new())
+                .unwrap_or_default()
                 .to_str()
                 .unwrap_or("")
                 .to_string(),
@@ -94,11 +93,11 @@ impl From<&[&str]> for MavenArtifact {
     fn from(slice: &[&str]) -> MavenArtifact {
         MavenArtifact {
             base: utils::jassets_path()
-                .unwrap_or(PathBuf::new())
+                .unwrap_or_default()
                 .to_str()
                 .unwrap_or("")
                 .to_string(),
-            group: slice.get(0).unwrap_or(&"").to_string(),
+            group: slice.first().unwrap_or(&"").to_string(),
             id: slice.get(1).unwrap_or(&"").to_string(),
             version: slice.get(2).unwrap_or(&"").to_string(),
             qualifier: slice.get(3).unwrap_or(&"").to_string(),
@@ -181,7 +180,7 @@ pub struct MavenArtifactRepo {
 impl From<&[&str]> for MavenArtifactRepo {
     fn from(slice: &[&str]) -> MavenArtifactRepo {
         MavenArtifactRepo {
-            _id: slice.get(0).unwrap_or(&"").to_string(),
+            _id: slice.first().unwrap_or(&"").to_string(),
             uri: slice.get(1).unwrap_or(&"").to_string(),
         }
     }

--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -158,19 +158,19 @@ pub(crate) fn primitive_of(inv_arg: &InvocationArg) -> Option<String> {
 
 pub(crate) fn get_class_name(inv_arg: &InvocationArg) -> &str {
     let class_name = match inv_arg {
-        &InvocationArg::Java {
+        InvocationArg::Java {
             instance: _,
-            ref class_name,
+            class_name,
             serialized: _,
         } => class_name,
-        &InvocationArg::Rust {
+        InvocationArg::Rust {
             json: _,
-            ref class_name,
+            class_name,
             serialized: _,
         } => class_name,
-        &InvocationArg::RustBasic {
+        InvocationArg::RustBasic {
             instance: _,
-            ref class_name,
+            class_name,
             serialized: _,
         } => class_name,
     };


### PR DESCRIPTION
This PR runs `cargo clippy --fix` and commits the changes it made.
You can reproduce the same changes by running that command yourself.

I have reviewed the changes and not seen anything controversial in there.
This includes:
* minor performance improvements - reduced allocations, clones etc.
* minor simplifications to the code - removal of needless `&`, removal of needless closures.
* I was a little surprised by the addition of `const` blocks in the `thread_local!` macros, but those were introduced by this lint https://rust-lang.github.io/rust-clippy/master/index.html#/thread_local_initializer_can_be_made_const which checks out.