### PR TITLE
Document how to run tests

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -33,4 +33,4 @@ jobs:
       - name: Build Rust with Cargo
         run: cargo build --manifest-path ./rust/Cargo.toml --verbose
       - name: Test Rust with Cargo
-        run: cargo test --manifest-path ./rust/Cargo.toml --verbose
+        run: cargo test --manifest-path ./rust/Cargo.toml --verbose -- --test-threads 1

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -33,4 +33,4 @@ jobs:
       - name: Build Rust with Cargo
         run: cargo build --manifest-path ./rust/Cargo.toml --verbose
       - name: Test Rust with Cargo
-        run: cargo test --manifest-path ./rust/Cargo.toml --verbose -- --test-threads 1
+        run: cargo test --manifest-path ./rust/Cargo.toml --verbose

--- a/README.md
+++ b/README.md
@@ -739,6 +739,17 @@ However, it also supports console logging, which is configured with setting the 
 
 Accepted values are `debug`, `info`, `warn`, `error` and `disabled`.
 
+## Running project tests
+
+First install java 17, this exact version is required.
+Then run the `run_tests.sh` script.
+This script will:
+
+* build and install j4rs and some java test code into the local maven repository on your machine.
+* run `cargo test` which relies on the above installed code.
+
+So you should rerun the full script every time you run tests.
+
 ## Licence
 
 At your option, under:

--- a/README.md
+++ b/README.md
@@ -741,7 +741,7 @@ Accepted values are `debug`, `info`, `warn`, `error` and `disabled`.
 
 ## Running project tests
 
-First install java 17, this exact version is required.
+First install a java version >= 9.
 Then run the `run_tests.sh` script.
 This script will:
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+mvn -f ./java/pom.xml --batch-mode --update-snapshots install
+mvn -f ./java/pom.xml --batch-mode --update-snapshots install
+mvn -f ./test-resources/java/pom.xml --batch-mode --update-snapshots install
+cargo test --manifest-path ./rust/Cargo.toml -- --test-threads 1 $@

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -3,4 +3,4 @@
 mvn -f ./java/pom.xml --batch-mode --update-snapshots install
 mvn -f ./java/pom.xml --batch-mode --update-snapshots install
 mvn -f ./test-resources/java/pom.xml --batch-mode --update-snapshots install
-cargo test --manifest-path ./rust/Cargo.toml -- --test-threads 1 $@
+cargo test --manifest-path ./rust/Cargo.toml -- $@


### PR DESCRIPTION
It was not clear to me how to run tests, I eventually figured it out and documented my findings here.

Instead of checking in the script we could provide a lengthy snippet of code for the user to copy/paste, but I think a script is much more convenient. Maybe we should also provide a .ps1 file for windows users?

On my machine many tests will fail when run concurrently, so I added `--test-threads 1` to both the script and the CI config. I think we somehow avoid this issue on CI since CI machines only have 2 cores.