### PR TITLE
Improve varargs/variadics docs

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -278,7 +278,9 @@ let instance = jvm.create_instance("java.lang.String", instantiation_args.as_ref
 jvm.cast(&instance, "java.lang.Object")?;
 ```
 
-### Java arrays and variadics
+### Java arrays and variadics/varargs
+
+In java varargs are internally implemented as arrays, so to keep the j4rs implementation simple, j4rs also handles varargs by passing an array in place of the varargs argument.
 
 ```rust
 // Create a Java array of Strings


### PR DESCRIPTION
closes https://github.com/astonbitecode/j4rs/issues/123

This PR does two important things:
* includes the word `varargs` in the docs, which is the actual term used by java, and the term that I searched for in the readme. When I found no results for varargs in the readme I incorrectly concluded that j4rs did not support varargs.
* Describes in words that varargs is supported by passing in an array. I am not very experienced in java so I did not know this and didnt realize thats what the example given was doing. A written description would have cleared up my confusion a lot sooner, so I've added one.