### PR TITLE
Add feature to Utils class to support a custom ClassLoader configuration

### DIFF
--- a/java/src/main/java/org/astonbitecode/j4rs/utils/Utils.java
+++ b/java/src/main/java/org/astonbitecode/j4rs/utils/Utils.java
@@ -25,6 +25,7 @@ import org.astonbitecode.j4rs.errors.InvocationException;
 public class Utils {
 
     private static boolean IsAndroid;
+    private static ClassLoader classloader = ClassLoader.getSystemClassLoader();
 
     static {
         try {
@@ -57,7 +58,7 @@ public class Utils {
                 return void.class;
             default:
                 if (!IsAndroid) {
-                    return Class.forName(className, true, ClassLoader.getSystemClassLoader());
+                    return Class.forName(className, true, classloader);
                 } else {
                     return Class.forName(className);
                 }
@@ -86,5 +87,14 @@ public class Utils {
         } else {
             return "Cannot create String out of a null Throwable";
         }
+    }
+
+    /** When the System ClassLoader is not able to load or retrieve your desired class,
+     * then use this method to update the behavior of Utils.forNameEnhanced()
+     *
+     * @param cl a ClassLoader with access to your class of interest.
+     */
+    public static void setClassloader(ClassLoader cl) {
+        classloader = cl;
     }
 }


### PR DESCRIPTION
Hello @astonbitecode .  I have been using j4rs for about 2 years now and it's really been a lifesaver.  Thank you for all of the effort you have put into it!  I've learned so much about the JavaVM internals in the process.

Submitting a PR with a suggested change to the Utils class.  My project's upstream recently switched to Java17 and this caused a problem in loading a class through j4rs (on the rust side).  In tracking down the details, Java17 disabled allowing substitution to the SystemClassLoader.  Some of the classes that I use through j4rs are loaded later in the program execution (as an eclipse plugin), and use a ClassLoader that Eclipse makes in that process.  With this change to Utils, I can allow j4rs to retrieve the classes and continue working. 

🥂