### PR TITLE
Prefer overloads with arguments with specific types over generics during method lookup

### DIFF
--- a/java/src/test/java/org/astonbitecode/j4rs/api/invocation/JsonInvocationImplTest.java
+++ b/java/src/test/java/org/astonbitecode/j4rs/api/invocation/JsonInvocationImplTest.java
@@ -298,6 +298,15 @@ public class JsonInvocationImplTest {
     }
 
     @Test
+    public void invokeOverloadWithGenerics() throws ClassNotFoundException {
+        JsonInvocationImpl instance = new JsonInvocationImpl(new MyTestTest(), MyTestTest.class);
+        Integer val = Integer.valueOf(42);
+
+        Instance result = instance.invoke("overloadedMethod", new InvocationArg(val.getClass().getName(), val));
+        assert (result.getObject().equals(val));
+    }
+
+    @Test
     public void checkEquals() {
         JsonInvocationImpl i1 = new JsonInvocationImpl(Integer.valueOf(3), Integer.class);
         JsonInvocationImpl i2 = new JsonInvocationImpl(Integer.valueOf(3), Integer.class);

--- a/java/src/test/java/org/astonbitecode/j4rs/tests/MyTestTest.java
+++ b/java/src/test/java/org/astonbitecode/j4rs/tests/MyTestTest.java
@@ -65,4 +65,16 @@ public class MyTestTest {
         });
         return result;
     }
+
+    public<T> Integer overloadedMethod(T val) {
+        if (val instanceof Integer) {
+            return ((Integer) val) * 2;
+        } else {
+            throw new IllegalArgumentException("Unsupported type");
+        }
+    }
+
+    public Integer overloadedMethod(Integer arg) {
+        return arg;
+    }
 }


### PR DESCRIPTION
When a class has a method that has multiple overloads, prefer overloads where arguments are of specific types over overloads that accept generic types.

To give a more concrete example, if I have the following overloads:

```
public void myMethod(Integer value) { ... } // overload 1
public<T> void myMethod(T value) { ... }    // overload 2
```

this change ensures that we always try to match parameter types against the overload that accepts `Integer` first. Since `T` matches anything, if we were to check the overload 2 first, we would always match it, even if the argument we are trying to match is of type `Integer` - this would result in us calling the wrong overload!

This order of matching is more consistent with what Java does when resolving calls to overloaded methods.